### PR TITLE
TOP2-770: add UAV telemetry schemas across all four languages

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -51,6 +51,7 @@ jobs:
             ros-${{ matrix.ros_distro }}-rosidl-default-generators \
             ros-${{ matrix.ros_distro }}-rosidl-default-runtime \
             ros-${{ matrix.ros_distro }}-std-msgs \
+            ros-${{ matrix.ros_distro }}-geometry-msgs \
             fakeroot \
             debhelper \
             devscripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -384,6 +384,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          lfs: true  # Golden CDR fixtures under testdata/ are LFS-tracked
 
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **UAV telemetry schemas (TOP2-770)** — seven ROS 2 common_interfaces
+  types plus one new EdgeFirst type, all with full Rust / Python /
+  C / C++ surface and golden CDR fixtures:
+
+  - `sensor_msgs/msg/MagneticField` — Header + Vector3 + float64[9].
+  - `sensor_msgs/msg/FluidPressure` — Header + float64 + variance.
+  - `sensor_msgs/msg/Temperature` — Header + float64 + variance.
+  - `sensor_msgs/msg/BatteryState` — Header + 7 f32 + 3 enum u8 + bool
+    + 2 f32 sequences + 2 strings. `POWER_SUPPLY_STATUS_*`,
+    `POWER_SUPPLY_HEALTH_*`, `POWER_SUPPLY_TECHNOLOGY_*` constants
+    exposed in all four languages.
+  - `nav_msgs/msg/Odometry` (new module) — Header + child_frame_id +
+    `PoseWithCovariance` + `TwistWithCovariance`.
+  - `geometry_msgs/msg/PoseWithCovariance` — `CdrFixed` (344 B).
+  - `geometry_msgs/msg/TwistWithCovariance` — `CdrFixed` (336 B).
+  - `edgefirst_msgs/msg/Vibration` (new schema) — Header + 2 u8 enums
+    (`MEASUREMENT_*`, `UNIT_*`) + f32 band + `Vector3 vibration` +
+    `uint32[] clipping`. Generalizes MAVLink VIBRATION, ArduPilot
+    VIBE, PX4 `vehicle_imu_status`, and ISO 10816/20816 industrial
+    broadband vibration sensors. Drives the `adis-uav-mavlink`
+    bridge's `flight/vibration` topic (TOP2-766).
+
+  Bindings across all four languages:
+
+  - Rust: `edgefirst_schemas::sensor_msgs::{MagneticField,
+    FluidPressure, Temperature, BatteryState}`,
+    `edgefirst_schemas::nav_msgs::Odometry`,
+    `edgefirst_schemas::edgefirst_msgs::Vibration`,
+    `geometry_msgs::{PoseWithCovariance, TwistWithCovariance}`.
+  - C: `ros_<type>_t` + `ros_<type>_from_cdr` / `_free` /
+    `_get_*` / `_as_cdr` accessors for buffer-backed types; `encode` /
+    `decode` pair for CdrFixed types. `ros_*` prefix retained for
+    consistency with the rest of the 3.x C API (per-namespace prefix
+    normalization deferred to 4.0.0).
+  - C++: header-only view classes `MagneticFieldView`,
+    `FluidPressureView`, `TemperatureView`, `BatteryStateView`,
+    `OdometryView`, `VibrationView` (move-only, non-owning), plus
+    value classes `PoseWithCovariance`, `TwistWithCovariance`.
+    `BatteryStateView` and `VibrationView` expose their constants as
+    `static constexpr` members.
+  - Python: dataclasses already present in
+    `edgefirst.schemas.{sensor_msgs, nav_msgs, geometry_msgs}`;
+    `edgefirst.schemas.edgefirst_msgs.Vibration` added with
+    `VibrationMeasurement` and `VibrationUnit` enums.
+
+  All six Header-prefixed buffer-backed types ship with a parametric
+  `frame_id`-length sweep test (lengths 0..=16) to lock in freedom
+  from the EDGEAI-1243 class of alignment bug.
+
 - **CameraFrame / CameraPlane** — new multi-plane video frame schema
   (`edgefirst_msgs/msg/CameraFrame`, `edgefirst_msgs/msg/CameraPlane`).
   Supports planar formats (NV12, I420, planar RGB HWC/NCHW, signed i8

--- a/edgefirst/schemas/edgefirst_msgs.py
+++ b/edgefirst/schemas/edgefirst_msgs.py
@@ -492,16 +492,16 @@ class Vibration(IdlStruct, typename='edgefirst_msgs/Vibration'):
     MAVLink publishers emit exactly 3 clipping entries (clipping_0/1/2).
     """
     header: Header = default_field(Header)
-    measurement_type: uint8 = 0
-    """Broadband statistic reported in `vibration` (see VibrationMeasurement)."""
-    unit: uint8 = 0
-    """Physical unit of `vibration` (see VibrationUnit)."""
+    vibration: Vector3 = default_field(Vector3)
+    """Per-axis vibration magnitude in the chosen unit/statistic."""
     band_lower_hz: float32 = 0.0
     """Integration band lower bound in Hz. NaN = unknown."""
     band_upper_hz: float32 = 0.0
     """Integration band upper bound in Hz. NaN = unknown."""
-    vibration: Vector3 = default_field(Vector3)
-    """Per-axis vibration magnitude in the chosen unit/statistic."""
+    measurement_type: uint8 = 0
+    """Broadband statistic reported in `vibration` (see VibrationMeasurement)."""
+    unit: uint8 = 0
+    """Physical unit of `vibration` (see VibrationUnit)."""
     clipping: sequence[uint32] = default_field([])
     """Per-axis accelerometer saturation counters (monotonic)."""
 

--- a/edgefirst/schemas/edgefirst_msgs.py
+++ b/edgefirst/schemas/edgefirst_msgs.py
@@ -494,9 +494,9 @@ class Vibration(IdlStruct, typename='edgefirst_msgs/Vibration'):
     header: Header = default_field(Header)
     vibration: Vector3 = default_field(Vector3)
     """Per-axis vibration magnitude in the chosen unit/statistic."""
-    band_lower_hz: float32 = 0.0
+    band_lower_hz: float32 = float("nan")
     """Integration band lower bound in Hz. NaN = unknown."""
-    band_upper_hz: float32 = 0.0
+    band_upper_hz: float32 = float("nan")
     """Integration band upper bound in Hz. NaN = unknown."""
     measurement_type: uint8 = 0
     """Broadband statistic reported in `vibration` (see VibrationMeasurement)."""

--- a/edgefirst/schemas/edgefirst_msgs.py
+++ b/edgefirst/schemas/edgefirst_msgs.py
@@ -11,6 +11,7 @@ from pycdr2.types import (float32, int16, int32, sequence, uint8, uint16,
 
 from . import default_field
 from .builtin_interfaces import Duration, Time
+from .geometry_msgs import Vector3
 from .std_msgs import Header
 
 class model_info(Enum):
@@ -458,6 +459,53 @@ class RadarInfo(IdlStruct, typename='edgefirst_msgs/RadarInfo'):
     """True if the radar is configured to output radar cubes."""
 
 
+class VibrationMeasurement(Enum):
+    """measurement_type enum values for Vibration."""
+    MEASUREMENT_UNKNOWN = 0
+    MEASUREMENT_RMS = 1
+    MEASUREMENT_PEAK = 2
+    MEASUREMENT_PEAK_TO_PEAK = 3
+
+
+class VibrationUnit(Enum):
+    """unit enum values for Vibration."""
+    UNIT_UNKNOWN = 0
+    UNIT_ACCEL_M_PER_S2 = 1
+    UNIT_ACCEL_G = 2
+    UNIT_VELOCITY_MM_PER_S = 3
+    UNIT_DISPLACEMENT_UM = 4
+    UNIT_VELOCITY_IN_PER_S = 5
+    UNIT_DISPLACEMENT_MIL = 6
+
+
+@dataclass
+class Vibration(IdlStruct, typename='edgefirst_msgs/Vibration'):
+    """
+    Per-axis vibration magnitude with explicit measurement semantics
+    (RMS/Peak/Peak-to-Peak), physical unit, and integration band.
+
+    Generalizes MAVLink VIBRATION, ArduPilot VIBE, PX4 vehicle_imu_status,
+    and industrial ISO 10816/20816 broadband vibration sensors.
+
+    Unknown scalars: NaN. Unknown enums: *_UNKNOWN (value 0).
+    Publishers without clipping source: clipping = [] (empty).
+    MAVLink publishers emit exactly 3 clipping entries (clipping_0/1/2).
+    """
+    header: Header = default_field(Header)
+    measurement_type: uint8 = 0
+    """Broadband statistic reported in `vibration` (see VibrationMeasurement)."""
+    unit: uint8 = 0
+    """Physical unit of `vibration` (see VibrationUnit)."""
+    band_lower_hz: float32 = 0.0
+    """Integration band lower bound in Hz. NaN = unknown."""
+    band_upper_hz: float32 = 0.0
+    """Integration band upper bound in Hz. NaN = unknown."""
+    vibration: Vector3 = default_field(Vector3)
+    """Per-axis vibration magnitude in the chosen unit/statistic."""
+    clipping: sequence[uint32] = default_field([])
+    """Per-axis accelerometer saturation counters (monotonic)."""
+
+
 # Schema registry support
 _TYPES = {
     "Box": Box,
@@ -473,6 +521,7 @@ _TYPES = {
     "RadarCube": RadarCube,
     "RadarInfo": RadarInfo,
     "Track": Track,
+    "Vibration": Vibration,
 }
 
 

--- a/edgefirst_msgs/CMakeLists.txt
+++ b/edgefirst_msgs/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -22,7 +23,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   msg/ModelInfo.msg
   msg/RadarCube.msg
   msg/Track.msg
-  DEPENDENCIES std_msgs)
+  msg/Vibration.msg
+  DEPENDENCIES std_msgs geometry_msgs)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/edgefirst_msgs/msg/Vibration.msg
+++ b/edgefirst_msgs/msg/Vibration.msg
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Au-Zone Technologies. All Rights Reserved.
+
+# Vibration Message Interface - edgefirst_msgs/msg/Vibration
+#
+# Per-axis vibration magnitude with explicit measurement semantics
+# (RMS/Peak/Peak-to-Peak), physical unit (accel / velocity / displacement),
+# and integration band. Generalizes MAVLink VIBRATION, ArduPilot VIBE,
+# PX4 vehicle_imu_status, and industrial ISO 10816/20816 broadband sensors.
+#
+# Producer convention for MAVLink bridges:
+#   measurement_type = MEASUREMENT_RMS
+#   unit             = UNIT_ACCEL_M_PER_S2
+#   band_lower_hz    = NaN   (unknown band)
+#   band_upper_hz    = NaN
+#   vibration.{x,y,z} = msg.vibration_{x,y,z}
+#   clipping         = [clipping_0, clipping_1, clipping_2]
+#   header.frame_id  = "imu_link"  (MAVLink --frame-id-imu default)
+#
+# Rules:
+#   - Unknown scalars: publish NaN (never 0.0).
+#   - Unknown enums: use the *_UNKNOWN variant (value 0).
+#   - Scalar broadband sensors populate vibration.x only and set
+#     vibration.y = vibration.z = NaN.
+#   - Multi-parameter publishers SHOULD publish one message per
+#     parameter on distinct key suffixes (e.g. vibration/velocity,
+#     vibration/accel).
+#   - Measurement direction (radial vs axial) comes from header.frame_id
+#     + TF, not an in-message field.
+#   - Publishers without clipping source: clipping = [] (empty).
+#     MAVLink publishers emit exactly 3 clipping entries.
+#   - ISO 20816-1 integration windows: 10-1000 Hz general,
+#     2-1000 Hz for low-speed machinery (<120 RPM).
+
+std_msgs/Header header
+
+# Broadband statistic reported in `vibration`.
+uint8 MEASUREMENT_UNKNOWN      = 0
+uint8 MEASUREMENT_RMS          = 1  # Broadband RMS (MAVLink, ISO 10816)
+uint8 MEASUREMENT_PEAK         = 2
+uint8 MEASUREMENT_PEAK_TO_PEAK = 3
+uint8 measurement_type
+
+# Physical unit of the values in `vibration`.
+uint8 UNIT_UNKNOWN           = 0
+uint8 UNIT_ACCEL_M_PER_S2    = 1  # MAVLink VIBRATION
+uint8 UNIT_ACCEL_G           = 2  # 1 g = 9.80665 m/s^2
+uint8 UNIT_VELOCITY_MM_PER_S = 3  # ISO 10816 broadband velocity
+uint8 UNIT_DISPLACEMENT_UM   = 4
+uint8 UNIT_VELOCITY_IN_PER_S = 5
+uint8 UNIT_DISPLACEMENT_MIL  = 6  # 1 mil = 25.4 um
+uint8 unit
+
+# Integration band (inclusive lower, inclusive upper). NaN = unknown.
+float32 band_lower_hz
+float32 band_upper_hz
+
+# Per-axis vibration magnitude in the chosen unit/statistic.
+# Unknown axis components: NaN (not 0.0).
+geometry_msgs/Vector3 vibration
+
+# Per-axis accelerometer saturation counters (monotonic). Empty when
+# the source does not expose clipping data. MAVLink publishers emit
+# exactly 3 entries (clipping_0/1/2).
+uint32[] clipping

--- a/edgefirst_msgs/msg/Vibration.msg
+++ b/edgefirst_msgs/msg/Vibration.msg
@@ -32,7 +32,20 @@
 #   - ISO 20816-1 integration windows: 10-1000 Hz general,
 #     2-1000 Hz for low-speed machinery (<120 RPM).
 
+# Field order is chosen by descending alignment (Vector3→f32→u8→seq)
+# so every field after the Header sits at a constant CDR offset relative
+# to `vibration`. This eliminates position-dependent internal padding and
+# allows single-offset O(1) accessors in the generated bindings.
+
 std_msgs/Header header
+
+# Per-axis vibration magnitude in the chosen unit/statistic.
+# Unknown axis components: NaN (not 0.0).
+geometry_msgs/Vector3 vibration
+
+# Integration band (inclusive lower, inclusive upper). NaN = unknown.
+float32 band_lower_hz
+float32 band_upper_hz
 
 # Broadband statistic reported in `vibration`.
 uint8 MEASUREMENT_UNKNOWN      = 0
@@ -50,14 +63,6 @@ uint8 UNIT_DISPLACEMENT_UM   = 4
 uint8 UNIT_VELOCITY_IN_PER_S = 5
 uint8 UNIT_DISPLACEMENT_MIL  = 6  # 1 mil = 25.4 um
 uint8 unit
-
-# Integration band (inclusive lower, inclusive upper). NaN = unknown.
-float32 band_lower_hz
-float32 band_upper_hz
-
-# Per-axis vibration magnitude in the chosen unit/statistic.
-# Unknown axis components: NaN (not 0.0).
-geometry_msgs/Vector3 vibration
 
 # Per-axis accelerometer saturation counters (monotonic). Empty when
 # the source does not expose clipping data. MAVLink publishers emit

--- a/edgefirst_msgs/package.xml
+++ b/edgefirst_msgs/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/include/edgefirst/schemas.h
+++ b/include/edgefirst/schemas.h
@@ -1627,6 +1627,208 @@ int16_t ros_local_time_get_timezone(const ros_local_time_t* view);
 /** @brief Borrow raw CDR bytes from the handle. */
 const uint8_t* ros_local_time_as_cdr(const ros_local_time_t* view, size_t* out_len);
 
+/* =========================================================================
+ * geometry_msgs/PoseWithCovariance  (CdrFixed)
+ * Pose(56 B) + float64[36] covariance = 344 bytes on the wire.
+ * =========================================================================
+ */
+int32_t ros_pose_with_covariance_encode(
+    uint8_t* buf, size_t cap, size_t* written,
+    double px, double py, double pz,
+    double ox, double oy, double oz, double ow,
+    const double* covariance);
+
+int32_t ros_pose_with_covariance_decode(
+    const uint8_t* data, size_t len,
+    double* px, double* py, double* pz,
+    double* ox, double* oy, double* oz, double* ow,
+    double* covariance_out);
+
+/* =========================================================================
+ * geometry_msgs/TwistWithCovariance  (CdrFixed)
+ * Twist(48 B) + float64[36] covariance = 336 bytes on the wire.
+ * =========================================================================
+ */
+int32_t ros_twist_with_covariance_encode(
+    uint8_t* buf, size_t cap, size_t* written,
+    double lx, double ly, double lz,
+    double ax, double ay, double az,
+    const double* covariance);
+
+int32_t ros_twist_with_covariance_decode(
+    const uint8_t* data, size_t len,
+    double* lx, double* ly, double* lz,
+    double* ax, double* ay, double* az,
+    double* covariance_out);
+
+/* =========================================================================
+ * sensor_msgs/MagneticField  (buffer-backed, decode-only)
+ * =========================================================================
+ */
+typedef struct ros_magnetic_field_t ros_magnetic_field_t;
+
+ros_magnetic_field_t* ros_magnetic_field_from_cdr(const uint8_t* data, size_t len);
+void ros_magnetic_field_free(ros_magnetic_field_t* view);
+int32_t ros_magnetic_field_get_stamp_sec(const ros_magnetic_field_t* view);
+uint32_t ros_magnetic_field_get_stamp_nanosec(const ros_magnetic_field_t* view);
+const char* ros_magnetic_field_get_frame_id(const ros_magnetic_field_t* view);
+void ros_magnetic_field_get_magnetic_field(const ros_magnetic_field_t* view,
+                                           double* x, double* y, double* z);
+void ros_magnetic_field_get_magnetic_field_covariance(
+    const ros_magnetic_field_t* view, double* out);
+/** @brief Borrow raw CDR bytes from the handle. */
+const uint8_t* ros_magnetic_field_as_cdr(const ros_magnetic_field_t* view, size_t* out_len);
+
+/* =========================================================================
+ * sensor_msgs/FluidPressure  (buffer-backed, decode-only)
+ * =========================================================================
+ */
+typedef struct ros_fluid_pressure_t ros_fluid_pressure_t;
+
+ros_fluid_pressure_t* ros_fluid_pressure_from_cdr(const uint8_t* data, size_t len);
+void ros_fluid_pressure_free(ros_fluid_pressure_t* view);
+int32_t ros_fluid_pressure_get_stamp_sec(const ros_fluid_pressure_t* view);
+uint32_t ros_fluid_pressure_get_stamp_nanosec(const ros_fluid_pressure_t* view);
+const char* ros_fluid_pressure_get_frame_id(const ros_fluid_pressure_t* view);
+double ros_fluid_pressure_get_fluid_pressure(const ros_fluid_pressure_t* view);
+double ros_fluid_pressure_get_variance(const ros_fluid_pressure_t* view);
+const uint8_t* ros_fluid_pressure_as_cdr(const ros_fluid_pressure_t* view, size_t* out_len);
+
+/* =========================================================================
+ * sensor_msgs/Temperature  (buffer-backed, decode-only)
+ * =========================================================================
+ */
+typedef struct ros_temperature_t ros_temperature_t;
+
+ros_temperature_t* ros_temperature_from_cdr(const uint8_t* data, size_t len);
+void ros_temperature_free(ros_temperature_t* view);
+int32_t ros_temperature_get_stamp_sec(const ros_temperature_t* view);
+uint32_t ros_temperature_get_stamp_nanosec(const ros_temperature_t* view);
+const char* ros_temperature_get_frame_id(const ros_temperature_t* view);
+double ros_temperature_get_temperature(const ros_temperature_t* view);
+double ros_temperature_get_variance(const ros_temperature_t* view);
+const uint8_t* ros_temperature_as_cdr(const ros_temperature_t* view, size_t* out_len);
+
+/* =========================================================================
+ * sensor_msgs/BatteryState  (buffer-backed, decode-only)
+ * =========================================================================
+ */
+/** power_supply_status values. */
+#define ROS_BATTERY_STATE_POWER_SUPPLY_STATUS_UNKNOWN      0
+#define ROS_BATTERY_STATE_POWER_SUPPLY_STATUS_CHARGING     1
+#define ROS_BATTERY_STATE_POWER_SUPPLY_STATUS_DISCHARGING  2
+#define ROS_BATTERY_STATE_POWER_SUPPLY_STATUS_NOT_CHARGING 3
+#define ROS_BATTERY_STATE_POWER_SUPPLY_STATUS_FULL         4
+
+/** power_supply_health values. */
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_UNKNOWN               0
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_GOOD                  1
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_OVERHEAT              2
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_DEAD                  3
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_OVERVOLTAGE           4
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_UNSPEC_FAILURE        5
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_COLD                  6
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_WATCHDOG_TIMER_EXPIRE 7
+#define ROS_BATTERY_STATE_POWER_SUPPLY_HEALTH_SAFETY_TIMER_EXPIRE   8
+
+/** power_supply_technology values. */
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_UNKNOWN 0
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_NIMH    1
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_LION    2
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_LIPO    3
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_LIFE    4
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_NICD    5
+#define ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_LIMN    6
+
+typedef struct ros_battery_state_t ros_battery_state_t;
+
+ros_battery_state_t* ros_battery_state_from_cdr(const uint8_t* data, size_t len);
+void ros_battery_state_free(ros_battery_state_t* view);
+int32_t ros_battery_state_get_stamp_sec(const ros_battery_state_t* view);
+uint32_t ros_battery_state_get_stamp_nanosec(const ros_battery_state_t* view);
+const char* ros_battery_state_get_frame_id(const ros_battery_state_t* view);
+float ros_battery_state_get_voltage(const ros_battery_state_t* view);
+float ros_battery_state_get_temperature(const ros_battery_state_t* view);
+float ros_battery_state_get_current(const ros_battery_state_t* view);
+float ros_battery_state_get_charge(const ros_battery_state_t* view);
+float ros_battery_state_get_capacity(const ros_battery_state_t* view);
+float ros_battery_state_get_design_capacity(const ros_battery_state_t* view);
+float ros_battery_state_get_percentage(const ros_battery_state_t* view);
+uint8_t ros_battery_state_get_power_supply_status(const ros_battery_state_t* view);
+uint8_t ros_battery_state_get_power_supply_health(const ros_battery_state_t* view);
+uint8_t ros_battery_state_get_power_supply_technology(const ros_battery_state_t* view);
+bool ros_battery_state_get_present(const ros_battery_state_t* view);
+uint32_t ros_battery_state_get_cell_voltage_len(const ros_battery_state_t* view);
+/** Copy up to `cap` cell voltages into `out`; returns total element count. */
+uint32_t ros_battery_state_get_cell_voltage(const ros_battery_state_t* view,
+                                            float* out, size_t cap);
+uint32_t ros_battery_state_get_cell_temperature_len(const ros_battery_state_t* view);
+uint32_t ros_battery_state_get_cell_temperature(const ros_battery_state_t* view,
+                                                float* out, size_t cap);
+const char* ros_battery_state_get_location(const ros_battery_state_t* view);
+const char* ros_battery_state_get_serial_number(const ros_battery_state_t* view);
+const uint8_t* ros_battery_state_as_cdr(const ros_battery_state_t* view, size_t* out_len);
+
+/* =========================================================================
+ * nav_msgs/Odometry  (buffer-backed, decode-only)
+ * =========================================================================
+ */
+typedef struct ros_odometry_t ros_odometry_t;
+
+ros_odometry_t* ros_odometry_from_cdr(const uint8_t* data, size_t len);
+void ros_odometry_free(ros_odometry_t* view);
+int32_t ros_odometry_get_stamp_sec(const ros_odometry_t* view);
+uint32_t ros_odometry_get_stamp_nanosec(const ros_odometry_t* view);
+const char* ros_odometry_get_frame_id(const ros_odometry_t* view);
+const char* ros_odometry_get_child_frame_id(const ros_odometry_t* view);
+void ros_odometry_get_pose(const ros_odometry_t* view,
+                           double* px, double* py, double* pz,
+                           double* ox, double* oy, double* oz, double* ow);
+void ros_odometry_get_pose_covariance(const ros_odometry_t* view, double* out);
+void ros_odometry_get_twist(const ros_odometry_t* view,
+                            double* lx, double* ly, double* lz,
+                            double* ax, double* ay, double* az);
+void ros_odometry_get_twist_covariance(const ros_odometry_t* view, double* out);
+const uint8_t* ros_odometry_as_cdr(const ros_odometry_t* view, size_t* out_len);
+
+/* =========================================================================
+ * edgefirst_msgs/Vibration  (buffer-backed, decode-only)
+ * =========================================================================
+ */
+/** measurement_type values. */
+#define ROS_VIBRATION_MEASUREMENT_UNKNOWN      0
+#define ROS_VIBRATION_MEASUREMENT_RMS          1
+#define ROS_VIBRATION_MEASUREMENT_PEAK         2
+#define ROS_VIBRATION_MEASUREMENT_PEAK_TO_PEAK 3
+
+/** unit values. */
+#define ROS_VIBRATION_UNIT_UNKNOWN           0
+#define ROS_VIBRATION_UNIT_ACCEL_M_PER_S2    1
+#define ROS_VIBRATION_UNIT_ACCEL_G           2
+#define ROS_VIBRATION_UNIT_VELOCITY_MM_PER_S 3
+#define ROS_VIBRATION_UNIT_DISPLACEMENT_UM   4
+#define ROS_VIBRATION_UNIT_VELOCITY_IN_PER_S 5
+#define ROS_VIBRATION_UNIT_DISPLACEMENT_MIL  6
+
+typedef struct ros_vibration_t ros_vibration_t;
+
+ros_vibration_t* ros_vibration_from_cdr(const uint8_t* data, size_t len);
+void ros_vibration_free(ros_vibration_t* view);
+int32_t ros_vibration_get_stamp_sec(const ros_vibration_t* view);
+uint32_t ros_vibration_get_stamp_nanosec(const ros_vibration_t* view);
+const char* ros_vibration_get_frame_id(const ros_vibration_t* view);
+uint8_t ros_vibration_get_measurement_type(const ros_vibration_t* view);
+uint8_t ros_vibration_get_unit(const ros_vibration_t* view);
+float ros_vibration_get_band_lower_hz(const ros_vibration_t* view);
+float ros_vibration_get_band_upper_hz(const ros_vibration_t* view);
+void ros_vibration_get_vibration(const ros_vibration_t* view,
+                                 double* x, double* y, double* z);
+uint32_t ros_vibration_get_clipping_len(const ros_vibration_t* view);
+/** Copy up to `cap` clipping counters into `out`; returns total element count. */
+uint32_t ros_vibration_get_clipping(const ros_vibration_t* view,
+                                    uint32_t* out, size_t cap);
+const uint8_t* ros_vibration_as_cdr(const ros_vibration_t* view, size_t* out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/edgefirst/schemas.hpp
+++ b/include/edgefirst/schemas.hpp
@@ -724,6 +724,96 @@ public:
     }
 };
 
+/// @brief ROS 2 `geometry_msgs::PoseWithCovariance` — Pose plus a 6×6
+///        row-major covariance matrix over (x, y, z, rotX, rotY, rotZ).
+class PoseWithCovariance {
+public:
+    Pose pose{};
+    std::array<double, 36> covariance{};
+
+    constexpr PoseWithCovariance() noexcept = default;
+    PoseWithCovariance(Pose p, std::array<double, 36> cov) noexcept
+        : pose(p), covariance(cov) {}
+
+    [[nodiscard]] static expected<PoseWithCovariance, Error>
+    decode(span<const std::uint8_t> data) noexcept {
+        PoseWithCovariance t;
+        if (ros_pose_with_covariance_decode(data.data(), data.size(),
+                                            &t.pose.px, &t.pose.py, &t.pose.pz,
+                                            &t.pose.ox, &t.pose.oy, &t.pose.oz, &t.pose.ow,
+                                            t.covariance.data()) != 0)
+            return unexpected<Error>(Error::from_errno("ros_pose_with_covariance_decode"));
+        return t;
+    }
+
+    [[nodiscard]] expected<std::size_t, Error>
+    encode(span<std::uint8_t> out) const noexcept {
+        std::size_t written = 0;
+        if (ros_pose_with_covariance_encode(out.data(), out.size(), &written,
+                                            pose.px, pose.py, pose.pz,
+                                            pose.ox, pose.oy, pose.oz, pose.ow,
+                                            covariance.data()) != 0)
+            return unexpected<Error>(Error::from_errno("ros_pose_with_covariance_encode"));
+        return written;
+    }
+
+    [[nodiscard]] expected<std::size_t, Error>
+    encoded_size() const noexcept {
+        std::size_t written = 0;
+        if (ros_pose_with_covariance_encode(nullptr, 0, &written,
+                                            pose.px, pose.py, pose.pz,
+                                            pose.ox, pose.oy, pose.oz, pose.ow,
+                                            covariance.data()) != 0)
+            return unexpected<Error>(Error::from_errno("ros_pose_with_covariance_encode"));
+        return written;
+    }
+};
+
+/// @brief ROS 2 `geometry_msgs::TwistWithCovariance` — Twist plus a 6×6
+///        row-major covariance matrix over (x, y, z, rotX, rotY, rotZ).
+class TwistWithCovariance {
+public:
+    Twist twist{};
+    std::array<double, 36> covariance{};
+
+    constexpr TwistWithCovariance() noexcept = default;
+    TwistWithCovariance(Twist t, std::array<double, 36> cov) noexcept
+        : twist(t), covariance(cov) {}
+
+    [[nodiscard]] static expected<TwistWithCovariance, Error>
+    decode(span<const std::uint8_t> data) noexcept {
+        TwistWithCovariance t;
+        if (ros_twist_with_covariance_decode(data.data(), data.size(),
+                                             &t.twist.lx, &t.twist.ly, &t.twist.lz,
+                                             &t.twist.ax, &t.twist.ay, &t.twist.az,
+                                             t.covariance.data()) != 0)
+            return unexpected<Error>(Error::from_errno("ros_twist_with_covariance_decode"));
+        return t;
+    }
+
+    [[nodiscard]] expected<std::size_t, Error>
+    encode(span<std::uint8_t> out) const noexcept {
+        std::size_t written = 0;
+        if (ros_twist_with_covariance_encode(out.data(), out.size(), &written,
+                                             twist.lx, twist.ly, twist.lz,
+                                             twist.ax, twist.ay, twist.az,
+                                             covariance.data()) != 0)
+            return unexpected<Error>(Error::from_errno("ros_twist_with_covariance_encode"));
+        return written;
+    }
+
+    [[nodiscard]] expected<std::size_t, Error>
+    encoded_size() const noexcept {
+        std::size_t written = 0;
+        if (ros_twist_with_covariance_encode(nullptr, 0, &written,
+                                             twist.lx, twist.ly, twist.lz,
+                                             twist.ax, twist.ay, twist.az,
+                                             covariance.data()) != 0)
+            return unexpected<Error>(Error::from_errno("ros_twist_with_covariance_encode"));
+        return written;
+    }
+};
+
 /// @brief ROS 2 `geometry_msgs::Accel` — linear and angular acceleration of
 ///        a rigid body in free space (m/s² and rad/s²).
 class Accel {
@@ -1305,6 +1395,54 @@ struct ModelInfoTraits {
     static constexpr auto free     = ros_model_info_free;
     static constexpr auto as_cdr   = ros_model_info_as_cdr;
     static constexpr std::string_view name = "ros_model_info";
+};
+
+struct MagneticFieldTraits {
+    using handle_type = ros_magnetic_field_t;
+    static constexpr auto from_cdr = ros_magnetic_field_from_cdr;
+    static constexpr auto free     = ros_magnetic_field_free;
+    static constexpr auto as_cdr   = ros_magnetic_field_as_cdr;
+    static constexpr std::string_view name = "ros_magnetic_field";
+};
+
+struct FluidPressureTraits {
+    using handle_type = ros_fluid_pressure_t;
+    static constexpr auto from_cdr = ros_fluid_pressure_from_cdr;
+    static constexpr auto free     = ros_fluid_pressure_free;
+    static constexpr auto as_cdr   = ros_fluid_pressure_as_cdr;
+    static constexpr std::string_view name = "ros_fluid_pressure";
+};
+
+struct TemperatureTraits {
+    using handle_type = ros_temperature_t;
+    static constexpr auto from_cdr = ros_temperature_from_cdr;
+    static constexpr auto free     = ros_temperature_free;
+    static constexpr auto as_cdr   = ros_temperature_as_cdr;
+    static constexpr std::string_view name = "ros_temperature";
+};
+
+struct BatteryStateTraits {
+    using handle_type = ros_battery_state_t;
+    static constexpr auto from_cdr = ros_battery_state_from_cdr;
+    static constexpr auto free     = ros_battery_state_free;
+    static constexpr auto as_cdr   = ros_battery_state_as_cdr;
+    static constexpr std::string_view name = "ros_battery_state";
+};
+
+struct OdometryTraits {
+    using handle_type = ros_odometry_t;
+    static constexpr auto from_cdr = ros_odometry_from_cdr;
+    static constexpr auto free     = ros_odometry_free;
+    static constexpr auto as_cdr   = ros_odometry_as_cdr;
+    static constexpr std::string_view name = "ros_odometry";
+};
+
+struct VibrationTraits {
+    using handle_type = ros_vibration_t;
+    static constexpr auto from_cdr = ros_vibration_from_cdr;
+    static constexpr auto free     = ros_vibration_free;
+    static constexpr auto as_cdr   = ros_vibration_as_cdr;
+    static constexpr std::string_view name = "ros_vibration";
 };
 
 /**
@@ -3350,6 +3488,296 @@ public:
     /// @note Valid only while this view and its backing buffer are alive.
     [[nodiscard]] std::string_view label(std::uint32_t index) const noexcept {
         return ros_model_info_get_label(handle(), index);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// sensor_msgs - MagneticField (view-only)
+// ---------------------------------------------------------------------------
+
+/// @brief Non-owning, move-only view over a `sensor_msgs::MagneticField`.
+class MagneticFieldView
+    : public detail::ViewBase<MagneticFieldView, detail::MagneticFieldTraits> {
+    using Base = detail::ViewBase<MagneticFieldView, detail::MagneticFieldTraits>;
+    friend Base;
+    using Base::Base;
+public:
+    using Base::from_cdr;
+    using Base::as_cdr;
+
+    [[nodiscard]] Time stamp() const noexcept {
+        return {ros_magnetic_field_get_stamp_sec(handle()),
+                ros_magnetic_field_get_stamp_nanosec(handle())};
+    }
+    [[nodiscard]] std::string_view frame_id() const noexcept {
+        return ros_magnetic_field_get_frame_id(handle());
+    }
+    [[nodiscard]] Vector3 magnetic_field() const noexcept {
+        Vector3 v;
+        ros_magnetic_field_get_magnetic_field(handle(), &v.x, &v.y, &v.z);
+        return v;
+    }
+    [[nodiscard]] std::array<double, 9> magnetic_field_covariance() const noexcept {
+        std::array<double, 9> cov{};
+        ros_magnetic_field_get_magnetic_field_covariance(handle(), cov.data());
+        return cov;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// sensor_msgs - FluidPressure (view-only)
+// ---------------------------------------------------------------------------
+
+class FluidPressureView
+    : public detail::ViewBase<FluidPressureView, detail::FluidPressureTraits> {
+    using Base = detail::ViewBase<FluidPressureView, detail::FluidPressureTraits>;
+    friend Base;
+    using Base::Base;
+public:
+    using Base::from_cdr;
+    using Base::as_cdr;
+
+    [[nodiscard]] Time stamp() const noexcept {
+        return {ros_fluid_pressure_get_stamp_sec(handle()),
+                ros_fluid_pressure_get_stamp_nanosec(handle())};
+    }
+    [[nodiscard]] std::string_view frame_id() const noexcept {
+        return ros_fluid_pressure_get_frame_id(handle());
+    }
+    [[nodiscard]] double fluid_pressure() const noexcept {
+        return ros_fluid_pressure_get_fluid_pressure(handle());
+    }
+    [[nodiscard]] double variance() const noexcept {
+        return ros_fluid_pressure_get_variance(handle());
+    }
+};
+
+// ---------------------------------------------------------------------------
+// sensor_msgs - Temperature (view-only)
+// ---------------------------------------------------------------------------
+
+class TemperatureView
+    : public detail::ViewBase<TemperatureView, detail::TemperatureTraits> {
+    using Base = detail::ViewBase<TemperatureView, detail::TemperatureTraits>;
+    friend Base;
+    using Base::Base;
+public:
+    using Base::from_cdr;
+    using Base::as_cdr;
+
+    [[nodiscard]] Time stamp() const noexcept {
+        return {ros_temperature_get_stamp_sec(handle()),
+                ros_temperature_get_stamp_nanosec(handle())};
+    }
+    [[nodiscard]] std::string_view frame_id() const noexcept {
+        return ros_temperature_get_frame_id(handle());
+    }
+    [[nodiscard]] double temperature() const noexcept {
+        return ros_temperature_get_temperature(handle());
+    }
+    [[nodiscard]] double variance() const noexcept {
+        return ros_temperature_get_variance(handle());
+    }
+};
+
+// ---------------------------------------------------------------------------
+// sensor_msgs - BatteryState (view-only)
+// ---------------------------------------------------------------------------
+
+class BatteryStateView
+    : public detail::ViewBase<BatteryStateView, detail::BatteryStateTraits> {
+    using Base = detail::ViewBase<BatteryStateView, detail::BatteryStateTraits>;
+    friend Base;
+    using Base::Base;
+public:
+    using Base::from_cdr;
+    using Base::as_cdr;
+
+    // power_supply_status
+    static constexpr std::uint8_t POWER_SUPPLY_STATUS_UNKNOWN      = 0;
+    static constexpr std::uint8_t POWER_SUPPLY_STATUS_CHARGING     = 1;
+    static constexpr std::uint8_t POWER_SUPPLY_STATUS_DISCHARGING  = 2;
+    static constexpr std::uint8_t POWER_SUPPLY_STATUS_NOT_CHARGING = 3;
+    static constexpr std::uint8_t POWER_SUPPLY_STATUS_FULL         = 4;
+
+    // power_supply_health
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_UNKNOWN               = 0;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_GOOD                  = 1;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_OVERHEAT              = 2;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_DEAD                  = 3;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_OVERVOLTAGE           = 4;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_UNSPEC_FAILURE        = 5;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_COLD                  = 6;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_WATCHDOG_TIMER_EXPIRE = 7;
+    static constexpr std::uint8_t POWER_SUPPLY_HEALTH_SAFETY_TIMER_EXPIRE   = 8;
+
+    // power_supply_technology
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_UNKNOWN = 0;
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_NIMH    = 1;
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_LION    = 2;
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_LIPO    = 3;
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_LIFE    = 4;
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_NICD    = 5;
+    static constexpr std::uint8_t POWER_SUPPLY_TECHNOLOGY_LIMN    = 6;
+
+    [[nodiscard]] Time stamp() const noexcept {
+        return {ros_battery_state_get_stamp_sec(handle()),
+                ros_battery_state_get_stamp_nanosec(handle())};
+    }
+    [[nodiscard]] std::string_view frame_id() const noexcept {
+        return ros_battery_state_get_frame_id(handle());
+    }
+    [[nodiscard]] float voltage() const noexcept {
+        return ros_battery_state_get_voltage(handle());
+    }
+    [[nodiscard]] float temperature() const noexcept {
+        return ros_battery_state_get_temperature(handle());
+    }
+    [[nodiscard]] float current() const noexcept {
+        return ros_battery_state_get_current(handle());
+    }
+    [[nodiscard]] float charge() const noexcept {
+        return ros_battery_state_get_charge(handle());
+    }
+    [[nodiscard]] float capacity() const noexcept {
+        return ros_battery_state_get_capacity(handle());
+    }
+    [[nodiscard]] float design_capacity() const noexcept {
+        return ros_battery_state_get_design_capacity(handle());
+    }
+    [[nodiscard]] float percentage() const noexcept {
+        return ros_battery_state_get_percentage(handle());
+    }
+    [[nodiscard]] std::uint8_t power_supply_status() const noexcept {
+        return ros_battery_state_get_power_supply_status(handle());
+    }
+    [[nodiscard]] std::uint8_t power_supply_health() const noexcept {
+        return ros_battery_state_get_power_supply_health(handle());
+    }
+    [[nodiscard]] std::uint8_t power_supply_technology() const noexcept {
+        return ros_battery_state_get_power_supply_technology(handle());
+    }
+    [[nodiscard]] bool present() const noexcept {
+        return ros_battery_state_get_present(handle());
+    }
+    [[nodiscard]] std::uint32_t cell_voltage_len() const noexcept {
+        return ros_battery_state_get_cell_voltage_len(handle());
+    }
+    /// @brief Copy up to `out.size()` cell voltages; returns total count.
+    std::uint32_t cell_voltage(span<float> out) const noexcept {
+        return ros_battery_state_get_cell_voltage(handle(), out.data(), out.size());
+    }
+    [[nodiscard]] std::uint32_t cell_temperature_len() const noexcept {
+        return ros_battery_state_get_cell_temperature_len(handle());
+    }
+    std::uint32_t cell_temperature(span<float> out) const noexcept {
+        return ros_battery_state_get_cell_temperature(handle(), out.data(), out.size());
+    }
+    [[nodiscard]] std::string_view location() const noexcept {
+        return ros_battery_state_get_location(handle());
+    }
+    [[nodiscard]] std::string_view serial_number() const noexcept {
+        return ros_battery_state_get_serial_number(handle());
+    }
+};
+
+// ---------------------------------------------------------------------------
+// nav_msgs - Odometry (view-only)
+// ---------------------------------------------------------------------------
+
+class OdometryView : public detail::ViewBase<OdometryView, detail::OdometryTraits> {
+    using Base = detail::ViewBase<OdometryView, detail::OdometryTraits>;
+    friend Base;
+    using Base::Base;
+public:
+    using Base::from_cdr;
+    using Base::as_cdr;
+
+    [[nodiscard]] Time stamp() const noexcept {
+        return {ros_odometry_get_stamp_sec(handle()),
+                ros_odometry_get_stamp_nanosec(handle())};
+    }
+    [[nodiscard]] std::string_view frame_id() const noexcept {
+        return ros_odometry_get_frame_id(handle());
+    }
+    [[nodiscard]] std::string_view child_frame_id() const noexcept {
+        return ros_odometry_get_child_frame_id(handle());
+    }
+    [[nodiscard]] PoseWithCovariance pose() const noexcept {
+        PoseWithCovariance p;
+        ros_odometry_get_pose(handle(),
+                              &p.pose.px, &p.pose.py, &p.pose.pz,
+                              &p.pose.ox, &p.pose.oy, &p.pose.oz, &p.pose.ow);
+        ros_odometry_get_pose_covariance(handle(), p.covariance.data());
+        return p;
+    }
+    [[nodiscard]] TwistWithCovariance twist() const noexcept {
+        TwistWithCovariance t;
+        ros_odometry_get_twist(handle(),
+                               &t.twist.lx, &t.twist.ly, &t.twist.lz,
+                               &t.twist.ax, &t.twist.ay, &t.twist.az);
+        ros_odometry_get_twist_covariance(handle(), t.covariance.data());
+        return t;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// edgefirst_msgs - Vibration (view-only)
+// ---------------------------------------------------------------------------
+
+class VibrationView : public detail::ViewBase<VibrationView, detail::VibrationTraits> {
+    using Base = detail::ViewBase<VibrationView, detail::VibrationTraits>;
+    friend Base;
+    using Base::Base;
+public:
+    using Base::from_cdr;
+    using Base::as_cdr;
+
+    // measurement_type
+    static constexpr std::uint8_t MEASUREMENT_UNKNOWN      = 0;
+    static constexpr std::uint8_t MEASUREMENT_RMS          = 1;
+    static constexpr std::uint8_t MEASUREMENT_PEAK         = 2;
+    static constexpr std::uint8_t MEASUREMENT_PEAK_TO_PEAK = 3;
+
+    // unit
+    static constexpr std::uint8_t UNIT_UNKNOWN           = 0;
+    static constexpr std::uint8_t UNIT_ACCEL_M_PER_S2    = 1;
+    static constexpr std::uint8_t UNIT_ACCEL_G           = 2;
+    static constexpr std::uint8_t UNIT_VELOCITY_MM_PER_S = 3;
+    static constexpr std::uint8_t UNIT_DISPLACEMENT_UM   = 4;
+    static constexpr std::uint8_t UNIT_VELOCITY_IN_PER_S = 5;
+    static constexpr std::uint8_t UNIT_DISPLACEMENT_MIL  = 6;
+
+    [[nodiscard]] Time stamp() const noexcept {
+        return {ros_vibration_get_stamp_sec(handle()),
+                ros_vibration_get_stamp_nanosec(handle())};
+    }
+    [[nodiscard]] std::string_view frame_id() const noexcept {
+        return ros_vibration_get_frame_id(handle());
+    }
+    [[nodiscard]] std::uint8_t measurement_type() const noexcept {
+        return ros_vibration_get_measurement_type(handle());
+    }
+    [[nodiscard]] std::uint8_t unit() const noexcept {
+        return ros_vibration_get_unit(handle());
+    }
+    [[nodiscard]] float band_lower_hz() const noexcept {
+        return ros_vibration_get_band_lower_hz(handle());
+    }
+    [[nodiscard]] float band_upper_hz() const noexcept {
+        return ros_vibration_get_band_upper_hz(handle());
+    }
+    [[nodiscard]] Vector3 vibration() const noexcept {
+        Vector3 v;
+        ros_vibration_get_vibration(handle(), &v.x, &v.y, &v.z);
+        return v;
+    }
+    [[nodiscard]] std::uint32_t clipping_len() const noexcept {
+        return ros_vibration_get_clipping_len(handle());
+    }
+    /// @brief Copy up to `out.size()` clipping counters; returns total count.
+    std::uint32_t clipping(span<std::uint32_t> out) const noexcept {
+        return ros_vibration_get_clipping(handle(), out.data(), out.size());
     }
 };
 

--- a/scripts/generate_cdr_testdata.py
+++ b/scripts/generate_cdr_testdata.py
@@ -34,6 +34,7 @@ from edgefirst.schemas import (
     edgefirst_msgs,
     foxglove_msgs,
     geometry_msgs,
+    nav_msgs,
     sensor_msgs,
     std_msgs,
 )
@@ -162,6 +163,52 @@ def gen_geometry_msgs():
               geometry_msgs.TransformStamped(
                   header=header, child_frame_id="child_frame", transform=tf))
 
+    # PoseWithCovariance — Pose + 36 covariance slots; non-zero diag + off-diag
+    pose_cov = [0.0] * 36
+    for i in range(6):
+        pose_cov[i * 6 + i] = 0.1 * (i + 1)  # diagonal 0.1..0.6
+    pose_cov[1] = 0.01   # pose cov(x,y) cross-term
+    pose_cov[6] = 0.01
+    write_cdr("geometry_msgs", "PoseWithCovariance",
+              geometry_msgs.PoseWithCovariance(
+                  pose=geometry_msgs.Pose(position=pos, orientation=quat),
+                  covariance=pose_cov))
+
+    twist_cov = [0.0] * 36
+    for i in range(6):
+        twist_cov[i * 6 + i] = 0.02 * (i + 1)
+    twist_cov[7] = 0.001
+    write_cdr("geometry_msgs", "TwistWithCovariance",
+              geometry_msgs.TwistWithCovariance(
+                  twist=geometry_msgs.Twist(linear=lin, angular=ang),
+                  covariance=twist_cov))
+
+
+def gen_nav_msgs():
+    header = std_msgs.Header(stamp=STAMP, frame_id=FRAME_ID)
+    pos = geometry_msgs.Point(x=1.5, y=-2.5, z=3.0)
+    quat = geometry_msgs.Quaternion(x=0.0, y=0.0, z=0.0, w=1.0)
+    lin = geometry_msgs.Vector3(x=1.0, y=2.0, z=3.0)
+    ang = geometry_msgs.Vector3(x=0.1, y=0.2, z=0.3)
+    pose_cov = [0.0] * 36
+    twist_cov = [0.0] * 36
+    for i in range(6):
+        pose_cov[i * 6 + i] = 0.1 * (i + 1)
+        twist_cov[i * 6 + i] = 0.02 * (i + 1)
+    pose_cov[1] = 0.01
+    pose_cov[6] = 0.01
+    twist_cov[7] = 0.001
+    write_cdr("nav_msgs", "Odometry",
+              nav_msgs.Odometry(
+                  header=header,
+                  child_frame_id="base_link",
+                  pose=geometry_msgs.PoseWithCovariance(
+                      pose=geometry_msgs.Pose(position=pos, orientation=quat),
+                      covariance=pose_cov),
+                  twist=geometry_msgs.TwistWithCovariance(
+                      twist=geometry_msgs.Twist(linear=lin, angular=ang),
+                      covariance=twist_cov)))
+
 
 def gen_std_msgs():
     write_cdr("std_msgs", "ColorRGBA",
@@ -236,6 +283,43 @@ def gen_sensor_msgs():
                   header=header, height=1, width=4, fields=fields,
                   is_bigendian=False, point_step=12, row_step=48,
                   data=list(pc_data), is_dense=True))
+
+    # MagneticField — Earth-field-magnitude sample
+    write_cdr("sensor_msgs", "MagneticField",
+              sensor_msgs.MagneticField(
+                  header=header,
+                  magnetic_field=geometry_msgs.Vector3(
+                      x=2.5e-5, y=-1.2e-5, z=4.1e-5),
+                  magnetic_field_covariance=[
+                      1e-10, 0.0, 0.0,
+                      0.0, 1e-10, 0.0,
+                      0.0, 0.0, 1e-10]))
+
+    # FluidPressure — standard atmospheric pressure in Pa
+    write_cdr("sensor_msgs", "FluidPressure",
+              sensor_msgs.FluidPressure(
+                  header=header, fluid_pressure=101325.0, variance=25.0))
+
+    # Temperature — 22.5 C with 0.01 C^2 variance
+    write_cdr("sensor_msgs", "Temperature",
+              sensor_msgs.Temperature(
+                  header=header, temperature=22.5, variance=0.01))
+
+    # BatteryState — 3S1P LiPo pack with full metadata
+    write_cdr("sensor_msgs", "BatteryState",
+              sensor_msgs.BatteryState(
+                  header=header,
+                  voltage=12.34, temperature=27.5, current=-2.1,
+                  charge=4.2, capacity=5.0, design_capacity=5.0,
+                  percentage=0.84,
+                  power_supply_status=2,       # DISCHARGING
+                  power_supply_health=1,       # GOOD
+                  power_supply_technology=3,   # LIPO
+                  present=True,
+                  cell_voltage=[4.11, 4.12, 4.10],
+                  cell_temperature=[27.1, 27.3, 27.4],
+                  location="battery0",
+                  serial_number="SN0123456"))
 
     # CameraInfo — minimal with plumb_bob distortion
     d_coeffs = [0.1, -0.2, 0.001, 0.002, 0.0]
@@ -510,6 +594,17 @@ def gen_edgefirst_msgs():
                   model_format="onnx",
                   model_name="mobilenet"))
 
+    # Vibration — MAVLink-style RMS in m/s^2 with 3 clipping counters
+    write_cdr("edgefirst_msgs", "Vibration",
+              edgefirst_msgs.Vibration(
+                  header=header,
+                  measurement_type=1,  # MEASUREMENT_RMS
+                  unit=1,              # UNIT_ACCEL_M_PER_S2
+                  band_lower_hz=10.0,
+                  band_upper_hz=1000.0,
+                  vibration=geometry_msgs.Vector3(x=0.42, y=0.51, z=0.37),
+                  clipping=[3, 1, 0]))
+
 
 def gen_foxglove_msgs():
     # CdrFixed types
@@ -595,6 +690,7 @@ def main():
         print("Generating golden CDR test files …")
     gen_builtin_interfaces()
     gen_geometry_msgs()
+    gen_nav_msgs()
     gen_std_msgs()
     gen_sensor_msgs()
     gen_edgefirst_msgs()

--- a/src/edgefirst_msgs.rs
+++ b/src/edgefirst_msgs.rs
@@ -2081,12 +2081,24 @@ pub mod vibration_unit {
 
 pub struct Vibration<B> {
     buf: B,
-    // [0]: measurement_type start (immediately after Header string).
-    // [1]: band_lower_hz start (f32-aligned from 2 bytes into [0] —
-    //      position-dependent, must be cursor-captured).
-    // [2]: Vector3 vibration start (8-aligned).
-    // [3]: clipping seq-count u32 start.
-    offsets: [usize; 4],
+    // offsets[0]: Vector3 `vibration` start (8-aligned after Header).
+    //
+    // Fields laid out by descending alignment (Vector3 → f32 → u8 → seq),
+    // so every subsequent field sits at a compile-time-constant delta
+    // from offsets[0]:
+    //
+    //   vibration           offsets[0]       (24 B)
+    //   band_lower_hz       offsets[0] + 24  (f32)
+    //   band_upper_hz       offsets[0] + 28  (f32)
+    //   measurement_type    offsets[0] + 32  (u8)
+    //   unit                offsets[0] + 33  (u8)
+    //   [ 2 bytes constant pad to 4-align ]
+    //   clipping seq-count  offsets[0] + 36  (u32)
+    //
+    // The 2-byte pad between `unit` and `clipping` is invariant because
+    // offsets[0] is 8-aligned (hence 4-aligned relative to CDR payload
+    // start). No position-dependent padding anywhere.
+    offsets: [usize; 1],
 }
 
 impl<B: AsRef<[u8]>> Vibration<B> {
@@ -2095,25 +2107,19 @@ impl<B: AsRef<[u8]>> Vibration<B> {
         let header = crate::std_msgs::Header::<&[u8]>::from_cdr(buf.as_ref())?;
         let pre = header.end_offset();
         let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        c.align(8);
         let o0 = c.offset();
+        Vector3::read_cdr(&mut c)?;
+        c.read_f32()?; // band_lower_hz
+        c.read_f32()?; // band_upper_hz
         c.read_u8()?; // measurement_type
         c.read_u8()?; // unit
         c.align(4);
-        let o1 = c.offset();
-        c.read_f32()?; // band_lower_hz
-        c.read_f32()?; // band_upper_hz
-        c.align(8);
-        let o2 = c.offset();
-        Vector3::read_cdr(&mut c)?;
-        let o3 = c.offset();
         let n = c.read_u32()? as usize;
         for _ in 0..n {
             c.read_u32()?;
         }
-        Ok(Vibration {
-            offsets: [o0, o1, o2, o3],
-            buf,
-        })
+        Ok(Vibration { offsets: [o0], buf })
     }
 
     /// Returns a `Header` view by re-parsing the CDR buffer prefix.
@@ -2127,28 +2133,28 @@ impl<B: AsRef<[u8]>> Vibration<B> {
     pub fn frame_id(&self) -> &str {
         rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
     }
-    pub fn measurement_type(&self) -> u8 {
-        rd_u8(self.buf.as_ref(), self.offsets[0])
-    }
-    pub fn unit(&self) -> u8 {
-        rd_u8(self.buf.as_ref(), self.offsets[0] + 1)
-    }
-    pub fn band_lower_hz(&self) -> f32 {
-        rd_f32(self.buf.as_ref(), self.offsets[1])
-    }
-    pub fn band_upper_hz(&self) -> f32 {
-        rd_f32(self.buf.as_ref(), self.offsets[1] + 4)
-    }
     pub fn vibration(&self) -> crate::geometry_msgs::Vector3 {
-        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[2]);
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[0]);
         crate::geometry_msgs::Vector3::read_cdr(&mut c)
             .expect("vibration validated during from_cdr")
     }
+    pub fn band_lower_hz(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 24)
+    }
+    pub fn band_upper_hz(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 28)
+    }
+    pub fn measurement_type(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0] + 32)
+    }
+    pub fn unit(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0] + 33)
+    }
     pub fn clipping_len(&self) -> u32 {
-        rd_u32(self.buf.as_ref(), self.offsets[3])
+        rd_u32(self.buf.as_ref(), self.offsets[0] + 36)
     }
     pub fn clipping(&self) -> Vec<u32> {
-        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[3]);
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[0] + 36);
         let n = c
             .read_u32()
             .expect("clipping length validated during from_cdr") as usize;
@@ -2185,17 +2191,14 @@ impl Vibration<Vec<u8>> {
         let mut sizer = CdrSizer::new();
         Time::size_cdr(&mut sizer);
         sizer.size_string(frame_id);
+        sizer.align(8);
         let o0 = sizer.offset();
+        Vector3::size_cdr(&mut sizer);
+        sizer.size_f32();
+        sizer.size_f32();
         sizer.size_u8();
         sizer.size_u8();
         sizer.align(4);
-        let o1 = sizer.offset();
-        sizer.size_f32();
-        sizer.size_f32();
-        sizer.align(8);
-        let o2 = sizer.offset();
-        Vector3::size_cdr(&mut sizer);
-        let o3 = sizer.offset();
         sizer.size_u32();
         for _ in clipping {
             sizer.size_u32();
@@ -2205,21 +2208,18 @@ impl Vibration<Vec<u8>> {
         let mut w = CdrWriter::new(&mut buf)?;
         stamp.write_cdr(&mut w);
         w.write_string(frame_id);
-        w.write_u8(measurement_type);
-        w.write_u8(unit);
+        vibration.write_cdr(&mut w);
         w.write_f32(band_lower_hz);
         w.write_f32(band_upper_hz);
-        vibration.write_cdr(&mut w);
+        w.write_u8(measurement_type);
+        w.write_u8(unit);
         w.write_u32(clipping.len() as u32);
         for v in clipping {
             w.write_u32(*v);
         }
         w.finish()?;
 
-        Ok(Vibration {
-            offsets: [o0, o1, o2, o3],
-            buf,
-        })
+        Ok(Vibration { offsets: [o0], buf })
     }
 
     pub fn into_cdr(self) -> Vec<u8> {

--- a/src/edgefirst_msgs.rs
+++ b/src/edgefirst_msgs.rs
@@ -2115,7 +2115,9 @@ impl<B: AsRef<[u8]>> Vibration<B> {
         c.read_u8()?; // measurement_type
         c.read_u8()?; // unit
         c.align(4);
-        let n = c.read_u32()? as usize;
+        // u32 = 4 bytes each; hardening check against pathological counts.
+        let raw = c.read_u32()?;
+        let n = c.check_seq_count(raw, 4)?;
         for _ in 0..n {
             c.read_u32()?;
         }

--- a/src/edgefirst_msgs.rs
+++ b/src/edgefirst_msgs.rs
@@ -2047,6 +2047,186 @@ impl ModelInfo<Vec<u8>> {
     }
 }
 
+// ── Vibration<B> ────────────────────────────────────────────────────
+//
+// CDR layout: Header → offsets[0] (measurement_type start, 1-aligned),
+//   uint8 measurement_type, uint8 unit,
+//   pad to 4 → (internal) float32 band_lower_hz, band_upper_hz (8 bytes),
+//   pad to 8 → offsets[1] (Vector3 vibration start),
+//   Vector3 vibration (24 bytes),
+//   uint32 count + uint32[] clipping → offsets[2] (seq-count u32 start).
+//
+// offsets[1] caches the aligned Vector3 start to sidestep the
+// EDGEAI-1243 class of bug; offsets[2] caches the clipping seq start
+// so num_clipping()/clipping() are O(1).
+
+/// `measurement_type` enum values for [`Vibration`].
+pub mod vibration_measurement {
+    pub const UNKNOWN: u8 = 0;
+    pub const RMS: u8 = 1;
+    pub const PEAK: u8 = 2;
+    pub const PEAK_TO_PEAK: u8 = 3;
+}
+
+/// `unit` enum values for [`Vibration`].
+pub mod vibration_unit {
+    pub const UNKNOWN: u8 = 0;
+    pub const ACCEL_M_PER_S2: u8 = 1;
+    pub const ACCEL_G: u8 = 2;
+    pub const VELOCITY_MM_PER_S: u8 = 3;
+    pub const DISPLACEMENT_UM: u8 = 4;
+    pub const VELOCITY_IN_PER_S: u8 = 5;
+    pub const DISPLACEMENT_MIL: u8 = 6;
+}
+
+pub struct Vibration<B> {
+    buf: B,
+    // [0]: measurement_type start (immediately after Header string).
+    // [1]: band_lower_hz start (f32-aligned from 2 bytes into [0] —
+    //      position-dependent, must be cursor-captured).
+    // [2]: Vector3 vibration start (8-aligned).
+    // [3]: clipping seq-count u32 start.
+    offsets: [usize; 4],
+}
+
+impl<B: AsRef<[u8]>> Vibration<B> {
+    pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
+        use crate::geometry_msgs::Vector3;
+        let header = crate::std_msgs::Header::<&[u8]>::from_cdr(buf.as_ref())?;
+        let pre = header.end_offset();
+        let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        let o0 = c.offset();
+        c.read_u8()?; // measurement_type
+        c.read_u8()?; // unit
+        c.align(4);
+        let o1 = c.offset();
+        c.read_f32()?; // band_lower_hz
+        c.read_f32()?; // band_upper_hz
+        c.align(8);
+        let o2 = c.offset();
+        Vector3::read_cdr(&mut c)?;
+        let o3 = c.offset();
+        let n = c.read_u32()? as usize;
+        for _ in 0..n {
+            c.read_u32()?;
+        }
+        Ok(Vibration {
+            offsets: [o0, o1, o2, o3],
+            buf,
+        })
+    }
+
+    /// Returns a `Header` view by re-parsing the CDR buffer prefix.
+    pub fn header(&self) -> crate::std_msgs::Header<&[u8]> {
+        crate::std_msgs::Header::from_cdr(self.buf.as_ref())
+            .expect("header bytes validated during from_cdr")
+    }
+    pub fn stamp(&self) -> crate::builtin_interfaces::Time {
+        rd_time(self.buf.as_ref(), CDR_HEADER_SIZE)
+    }
+    pub fn frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
+    }
+    pub fn measurement_type(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0])
+    }
+    pub fn unit(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0] + 1)
+    }
+    pub fn band_lower_hz(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[1])
+    }
+    pub fn band_upper_hz(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[1] + 4)
+    }
+    pub fn vibration(&self) -> crate::geometry_msgs::Vector3 {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[2]);
+        crate::geometry_msgs::Vector3::read_cdr(&mut c)
+            .expect("vibration validated during from_cdr")
+    }
+    pub fn clipping_len(&self) -> u32 {
+        rd_u32(self.buf.as_ref(), self.offsets[3])
+    }
+    pub fn clipping(&self) -> Vec<u32> {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[3]);
+        let n = c
+            .read_u32()
+            .expect("clipping length validated during from_cdr") as usize;
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            out.push(
+                c.read_u32()
+                    .expect("clipping element validated during from_cdr"),
+            );
+        }
+        out
+    }
+    pub fn as_cdr(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+    pub fn to_cdr(&self) -> Vec<u8> {
+        self.buf.as_ref().to_vec()
+    }
+}
+
+impl Vibration<Vec<u8>> {
+    pub fn new(
+        stamp: crate::builtin_interfaces::Time,
+        frame_id: &str,
+        measurement_type: u8,
+        unit: u8,
+        band_lower_hz: f32,
+        band_upper_hz: f32,
+        vibration: crate::geometry_msgs::Vector3,
+        clipping: &[u32],
+    ) -> Result<Self, CdrError> {
+        use crate::builtin_interfaces::Time;
+        use crate::geometry_msgs::Vector3;
+        let mut sizer = CdrSizer::new();
+        Time::size_cdr(&mut sizer);
+        sizer.size_string(frame_id);
+        let o0 = sizer.offset();
+        sizer.size_u8();
+        sizer.size_u8();
+        sizer.align(4);
+        let o1 = sizer.offset();
+        sizer.size_f32();
+        sizer.size_f32();
+        sizer.align(8);
+        let o2 = sizer.offset();
+        Vector3::size_cdr(&mut sizer);
+        let o3 = sizer.offset();
+        sizer.size_u32();
+        for _ in clipping {
+            sizer.size_u32();
+        }
+
+        let mut buf = vec![0u8; sizer.size()];
+        let mut w = CdrWriter::new(&mut buf)?;
+        stamp.write_cdr(&mut w);
+        w.write_string(frame_id);
+        w.write_u8(measurement_type);
+        w.write_u8(unit);
+        w.write_f32(band_lower_hz);
+        w.write_f32(band_upper_hz);
+        vibration.write_cdr(&mut w);
+        w.write_u32(clipping.len() as u32);
+        for v in clipping {
+            w.write_u32(*v);
+        }
+        w.finish()?;
+
+        Ok(Vibration {
+            offsets: [o0, o1, o2, o3],
+            buf,
+        })
+    }
+
+    pub fn into_cdr(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
 // ── Registry ────────────────────────────────────────────────────────
 
 /// Check if a type name is supported by this module.
@@ -2066,6 +2246,7 @@ pub fn is_type_supported(type_name: &str) -> bool {
             | "RadarCube"
             | "RadarInfo"
             | "Track"
+            | "Vibration"
     )
 }
 
@@ -2085,6 +2266,7 @@ pub fn list_types() -> &'static [&'static str] {
         "edgefirst_msgs/msg/RadarCube",
         "edgefirst_msgs/msg/RadarInfo",
         "edgefirst_msgs/msg/Track",
+        "edgefirst_msgs/msg/Vibration",
     ]
 }
 

--- a/src/edgefirst_msgs.rs
+++ b/src/edgefirst_msgs.rs
@@ -2158,6 +2158,11 @@ impl<B: AsRef<[u8]>> Vibration<B> {
     pub fn clipping_len(&self) -> u32 {
         rd_u32(self.buf.as_ref(), self.offsets[0] + 36)
     }
+    /// Byte offset of the `clipping` sequence (u32 count, then elements).
+    /// Exposed for allocation-free decoders (e.g. FFI).
+    pub fn clipping_seq_offset(&self) -> usize {
+        self.offsets[0] + 36
+    }
     pub fn clipping(&self) -> Vec<u32> {
         let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[0] + 36);
         let n = c

--- a/src/edgefirst_msgs.rs
+++ b/src/edgefirst_msgs.rs
@@ -2049,16 +2049,19 @@ impl ModelInfo<Vec<u8>> {
 
 // ── Vibration<B> ────────────────────────────────────────────────────
 //
-// CDR layout: Header → offsets[0] (measurement_type start, 1-aligned),
-//   uint8 measurement_type, uint8 unit,
-//   pad to 4 → (internal) float32 band_lower_hz, band_upper_hz (8 bytes),
-//   pad to 8 → offsets[1] (Vector3 vibration start),
+// CDR layout: Header → pad to 8 → offsets[0] (Vector3 vibration start),
 //   Vector3 vibration (24 bytes),
-//   uint32 count + uint32[] clipping → offsets[2] (seq-count u32 start).
+//   float32 band_lower_hz, float32 band_upper_hz,
+//   uint8 measurement_type, uint8 unit,
+//   pad to 4 → uint32 count + uint32[] clipping.
 //
-// offsets[1] caches the aligned Vector3 start to sidestep the
-// EDGEAI-1243 class of bug; offsets[2] caches the clipping seq start
-// so num_clipping()/clipping() are O(1).
+// offsets contains a single cached value:
+//   offsets[0] = aligned start of `vibration`.
+//
+// All remaining fields are accessed at fixed compile-time-constant
+// deltas from offsets[0] (including the clipping sequence count/data)
+// because fields are ordered by descending alignment, sidestepping the
+// EDGEAI-1243 class of bug entirely.
 
 /// `measurement_type` enum values for [`Vibration`].
 pub mod vibration_measurement {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -35,6 +35,7 @@ use crate::cdr::{self, CdrFixed};
 use crate::edgefirst_msgs;
 use crate::foxglove_msgs;
 use crate::geometry_msgs::{self, *};
+use crate::nav_msgs;
 use crate::sensor_msgs::{self, NavSatStatus};
 use crate::std_msgs;
 
@@ -3345,6 +3346,12 @@ impl_as_cdr!(ros_point_cloud2_as_cdr, ros_point_cloud2_t);
 impl_as_cdr!(ros_camera_info_as_cdr, ros_camera_info_t);
 impl_as_cdr!(ros_track_as_cdr, ros_track_t);
 impl_as_cdr!(ros_local_time_as_cdr, ros_local_time_t);
+impl_as_cdr!(ros_magnetic_field_as_cdr, ros_magnetic_field_t);
+impl_as_cdr!(ros_fluid_pressure_as_cdr, ros_fluid_pressure_t);
+impl_as_cdr!(ros_temperature_as_cdr, ros_temperature_t);
+impl_as_cdr!(ros_battery_state_as_cdr, ros_battery_state_t);
+impl_as_cdr!(ros_odometry_as_cdr, ros_odometry_t);
+impl_as_cdr!(ros_vibration_as_cdr, ros_vibration_t);
 
 // ros_detect_t and ros_model_t use named fields, so they need manual as_cdr impls.
 
@@ -3389,3 +3396,941 @@ pub extern "C" fn ros_model_as_cdr(view: *const ros_model_t, out_len: *mut usize
 // ros_box_as_cdr and ros_mask_as_cdr have been removed. Forwarding an embedded
 // child box/mask as a standalone CDR would require re-encoding, which violates
 // the zero-copy contract. See CAPI.md for details.
+
+// =============================================================================
+// PoseWithCovariance (CdrFixed)
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn ros_pose_with_covariance_encode(
+    buf: *mut u8,
+    cap: usize,
+    written: *mut usize,
+    px: f64,
+    py: f64,
+    pz: f64,
+    ox: f64,
+    oy: f64,
+    oz: f64,
+    ow: f64,
+    covariance: *const f64,
+) -> i32 {
+    if covariance.is_null() {
+        set_errno(EINVAL);
+        return -1;
+    }
+    let mut cov = [0.0_f64; 36];
+    unsafe {
+        ptr::copy_nonoverlapping(covariance, cov.as_mut_ptr(), 36);
+    }
+    let val = PoseWithCovariance {
+        pose: Pose {
+            position: Point {
+                x: px,
+                y: py,
+                z: pz,
+            },
+            orientation: Quaternion {
+                x: ox,
+                y: oy,
+                z: oz,
+                w: ow,
+            },
+        },
+        covariance: cov,
+    };
+    encode_fixed_to_buf(&val, buf, cap, written)
+}
+
+#[no_mangle]
+pub extern "C" fn ros_pose_with_covariance_decode(
+    data: *const u8,
+    len: usize,
+    px: *mut f64,
+    py: *mut f64,
+    pz: *mut f64,
+    ox: *mut f64,
+    oy: *mut f64,
+    oz: *mut f64,
+    ow: *mut f64,
+    covariance_out: *mut f64,
+) -> i32 {
+    match decode_fixed_from_buf::<PoseWithCovariance>(data, len) {
+        Ok(v) => unsafe {
+            if !px.is_null() {
+                *px = v.pose.position.x;
+            }
+            if !py.is_null() {
+                *py = v.pose.position.y;
+            }
+            if !pz.is_null() {
+                *pz = v.pose.position.z;
+            }
+            if !ox.is_null() {
+                *ox = v.pose.orientation.x;
+            }
+            if !oy.is_null() {
+                *oy = v.pose.orientation.y;
+            }
+            if !oz.is_null() {
+                *oz = v.pose.orientation.z;
+            }
+            if !ow.is_null() {
+                *ow = v.pose.orientation.w;
+            }
+            if !covariance_out.is_null() {
+                ptr::copy_nonoverlapping(v.covariance.as_ptr(), covariance_out, 36);
+            }
+            0
+        },
+        Err(()) => -1,
+    }
+}
+
+// =============================================================================
+// TwistWithCovariance (CdrFixed)
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn ros_twist_with_covariance_encode(
+    buf: *mut u8,
+    cap: usize,
+    written: *mut usize,
+    lx: f64,
+    ly: f64,
+    lz: f64,
+    ax: f64,
+    ay: f64,
+    az: f64,
+    covariance: *const f64,
+) -> i32 {
+    if covariance.is_null() {
+        set_errno(EINVAL);
+        return -1;
+    }
+    let mut cov = [0.0_f64; 36];
+    unsafe {
+        ptr::copy_nonoverlapping(covariance, cov.as_mut_ptr(), 36);
+    }
+    let val = TwistWithCovariance {
+        twist: Twist {
+            linear: Vector3 {
+                x: lx,
+                y: ly,
+                z: lz,
+            },
+            angular: Vector3 {
+                x: ax,
+                y: ay,
+                z: az,
+            },
+        },
+        covariance: cov,
+    };
+    encode_fixed_to_buf(&val, buf, cap, written)
+}
+
+#[no_mangle]
+pub extern "C" fn ros_twist_with_covariance_decode(
+    data: *const u8,
+    len: usize,
+    lx: *mut f64,
+    ly: *mut f64,
+    lz: *mut f64,
+    ax: *mut f64,
+    ay: *mut f64,
+    az: *mut f64,
+    covariance_out: *mut f64,
+) -> i32 {
+    match decode_fixed_from_buf::<TwistWithCovariance>(data, len) {
+        Ok(v) => unsafe {
+            if !lx.is_null() {
+                *lx = v.twist.linear.x;
+            }
+            if !ly.is_null() {
+                *ly = v.twist.linear.y;
+            }
+            if !lz.is_null() {
+                *lz = v.twist.linear.z;
+            }
+            if !ax.is_null() {
+                *ax = v.twist.angular.x;
+            }
+            if !ay.is_null() {
+                *ay = v.twist.angular.y;
+            }
+            if !az.is_null() {
+                *az = v.twist.angular.z;
+            }
+            if !covariance_out.is_null() {
+                ptr::copy_nonoverlapping(v.covariance.as_ptr(), covariance_out, 36);
+            }
+            0
+        },
+        Err(()) => -1,
+    }
+}
+
+// =============================================================================
+// MagneticField (buffer-backed)
+// =============================================================================
+
+pub struct ros_magnetic_field_t(sensor_msgs::MagneticField<&'static [u8]>);
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_from_cdr(
+    data: *const u8,
+    len: usize,
+) -> *mut ros_magnetic_field_t {
+    check_null_ret_null!(data);
+    let slice = unsafe { slice::from_raw_parts(data, len) };
+    match sensor_msgs::MagneticField::from_cdr(unsafe { erase_lifetime(slice) }) {
+        Ok(v) => Box::into_raw(Box::new(ros_magnetic_field_t(v))),
+        Err(_) => {
+            set_errno(EBADMSG);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_free(view: *mut ros_magnetic_field_t) {
+    if !view.is_null() {
+        unsafe {
+            drop(Box::from_raw(view));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_get_stamp_sec(view: *const ros_magnetic_field_t) -> i32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().sec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_get_stamp_nanosec(view: *const ros_magnetic_field_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().nanosec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_get_frame_id(
+    view: *const ros_magnetic_field_t,
+) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.frame_id() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_get_magnetic_field(
+    view: *const ros_magnetic_field_t,
+    x: *mut f64,
+    y: *mut f64,
+    z: *mut f64,
+) {
+    if view.is_null() {
+        return;
+    }
+    let v = unsafe { (*view).0.magnetic_field() };
+    unsafe {
+        if !x.is_null() {
+            *x = v.x;
+        }
+        if !y.is_null() {
+            *y = v.y;
+        }
+        if !z.is_null() {
+            *z = v.z;
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_magnetic_field_get_magnetic_field_covariance(
+    view: *const ros_magnetic_field_t,
+    out: *mut f64,
+) {
+    if view.is_null() || out.is_null() {
+        return;
+    }
+    let cov = unsafe { (*view).0.magnetic_field_covariance() };
+    unsafe {
+        ptr::copy_nonoverlapping(cov.as_ptr(), out, 9);
+    }
+}
+
+// =============================================================================
+// FluidPressure (buffer-backed)
+// =============================================================================
+
+pub struct ros_fluid_pressure_t(sensor_msgs::FluidPressure<&'static [u8]>);
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_from_cdr(
+    data: *const u8,
+    len: usize,
+) -> *mut ros_fluid_pressure_t {
+    check_null_ret_null!(data);
+    let slice = unsafe { slice::from_raw_parts(data, len) };
+    match sensor_msgs::FluidPressure::from_cdr(unsafe { erase_lifetime(slice) }) {
+        Ok(v) => Box::into_raw(Box::new(ros_fluid_pressure_t(v))),
+        Err(_) => {
+            set_errno(EBADMSG);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_free(view: *mut ros_fluid_pressure_t) {
+    if !view.is_null() {
+        unsafe {
+            drop(Box::from_raw(view));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_get_stamp_sec(view: *const ros_fluid_pressure_t) -> i32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().sec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_get_stamp_nanosec(view: *const ros_fluid_pressure_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().nanosec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_get_frame_id(
+    view: *const ros_fluid_pressure_t,
+) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.frame_id() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_get_fluid_pressure(view: *const ros_fluid_pressure_t) -> f64 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.fluid_pressure() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_fluid_pressure_get_variance(view: *const ros_fluid_pressure_t) -> f64 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.variance() }
+}
+
+// =============================================================================
+// Temperature (buffer-backed)
+// =============================================================================
+
+pub struct ros_temperature_t(sensor_msgs::Temperature<&'static [u8]>);
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_from_cdr(data: *const u8, len: usize) -> *mut ros_temperature_t {
+    check_null_ret_null!(data);
+    let slice = unsafe { slice::from_raw_parts(data, len) };
+    match sensor_msgs::Temperature::from_cdr(unsafe { erase_lifetime(slice) }) {
+        Ok(v) => Box::into_raw(Box::new(ros_temperature_t(v))),
+        Err(_) => {
+            set_errno(EBADMSG);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_free(view: *mut ros_temperature_t) {
+    if !view.is_null() {
+        unsafe {
+            drop(Box::from_raw(view));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_get_stamp_sec(view: *const ros_temperature_t) -> i32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().sec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_get_stamp_nanosec(view: *const ros_temperature_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().nanosec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_get_frame_id(view: *const ros_temperature_t) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.frame_id() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_get_temperature(view: *const ros_temperature_t) -> f64 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.temperature() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_temperature_get_variance(view: *const ros_temperature_t) -> f64 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.variance() }
+}
+
+// =============================================================================
+// BatteryState (buffer-backed)
+// =============================================================================
+
+pub struct ros_battery_state_t(sensor_msgs::BatteryState<&'static [u8]>);
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_from_cdr(
+    data: *const u8,
+    len: usize,
+) -> *mut ros_battery_state_t {
+    check_null_ret_null!(data);
+    let slice = unsafe { slice::from_raw_parts(data, len) };
+    match sensor_msgs::BatteryState::from_cdr(unsafe { erase_lifetime(slice) }) {
+        Ok(v) => Box::into_raw(Box::new(ros_battery_state_t(v))),
+        Err(_) => {
+            set_errno(EBADMSG);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_free(view: *mut ros_battery_state_t) {
+    if !view.is_null() {
+        unsafe {
+            drop(Box::from_raw(view));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_stamp_sec(view: *const ros_battery_state_t) -> i32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().sec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_stamp_nanosec(view: *const ros_battery_state_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().nanosec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_frame_id(
+    view: *const ros_battery_state_t,
+) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.frame_id() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_voltage(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.voltage() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_temperature(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.temperature() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_current(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.current() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_charge(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.charge() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_capacity(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.capacity() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_design_capacity(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.design_capacity() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_percentage(view: *const ros_battery_state_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.percentage() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_power_supply_status(
+    view: *const ros_battery_state_t,
+) -> u8 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.power_supply_status() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_power_supply_health(
+    view: *const ros_battery_state_t,
+) -> u8 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.power_supply_health() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_power_supply_technology(
+    view: *const ros_battery_state_t,
+) -> u8 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.power_supply_technology() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_present(view: *const ros_battery_state_t) -> bool {
+    if view.is_null() {
+        return false;
+    }
+    unsafe { (*view).0.present() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_cell_voltage_len(view: *const ros_battery_state_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.cell_voltage_len() }
+}
+
+/// Copy up to `cap` cell voltages into `out`; returns the total element count.
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_cell_voltage(
+    view: *const ros_battery_state_t,
+    out: *mut f32,
+    cap: usize,
+) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    let cells = unsafe { (*view).0.cell_voltage() };
+    let n = cells.len();
+    if !out.is_null() && cap > 0 {
+        let copy_n = n.min(cap);
+        unsafe {
+            ptr::copy_nonoverlapping(cells.as_ptr(), out, copy_n);
+        }
+    }
+    n as u32
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_cell_temperature_len(
+    view: *const ros_battery_state_t,
+) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.cell_temperature_len() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_cell_temperature(
+    view: *const ros_battery_state_t,
+    out: *mut f32,
+    cap: usize,
+) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    let cells = unsafe { (*view).0.cell_temperature() };
+    let n = cells.len();
+    if !out.is_null() && cap > 0 {
+        let copy_n = n.min(cap);
+        unsafe {
+            ptr::copy_nonoverlapping(cells.as_ptr(), out, copy_n);
+        }
+    }
+    n as u32
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_location(
+    view: *const ros_battery_state_t,
+) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.location() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_battery_state_get_serial_number(
+    view: *const ros_battery_state_t,
+) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.serial_number() })
+}
+
+// =============================================================================
+// Odometry (buffer-backed)
+// =============================================================================
+
+pub struct ros_odometry_t(nav_msgs::Odometry<&'static [u8]>);
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_from_cdr(data: *const u8, len: usize) -> *mut ros_odometry_t {
+    check_null_ret_null!(data);
+    let slice = unsafe { slice::from_raw_parts(data, len) };
+    match nav_msgs::Odometry::from_cdr(unsafe { erase_lifetime(slice) }) {
+        Ok(v) => Box::into_raw(Box::new(ros_odometry_t(v))),
+        Err(_) => {
+            set_errno(EBADMSG);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_free(view: *mut ros_odometry_t) {
+    if !view.is_null() {
+        unsafe {
+            drop(Box::from_raw(view));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_stamp_sec(view: *const ros_odometry_t) -> i32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().sec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_stamp_nanosec(view: *const ros_odometry_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().nanosec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_frame_id(view: *const ros_odometry_t) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.frame_id() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_child_frame_id(view: *const ros_odometry_t) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.child_frame_id() })
+}
+
+/// Write pose position (x,y,z) + orientation (x,y,z,w) out.
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_pose(
+    view: *const ros_odometry_t,
+    px: *mut f64,
+    py: *mut f64,
+    pz: *mut f64,
+    ox: *mut f64,
+    oy: *mut f64,
+    oz: *mut f64,
+    ow: *mut f64,
+) {
+    if view.is_null() {
+        return;
+    }
+    let p = unsafe { (*view).0.pose() };
+    unsafe {
+        if !px.is_null() {
+            *px = p.pose.position.x;
+        }
+        if !py.is_null() {
+            *py = p.pose.position.y;
+        }
+        if !pz.is_null() {
+            *pz = p.pose.position.z;
+        }
+        if !ox.is_null() {
+            *ox = p.pose.orientation.x;
+        }
+        if !oy.is_null() {
+            *oy = p.pose.orientation.y;
+        }
+        if !oz.is_null() {
+            *oz = p.pose.orientation.z;
+        }
+        if !ow.is_null() {
+            *ow = p.pose.orientation.w;
+        }
+    }
+}
+
+/// Write 36-element pose covariance.
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_pose_covariance(view: *const ros_odometry_t, out: *mut f64) {
+    if view.is_null() || out.is_null() {
+        return;
+    }
+    let p = unsafe { (*view).0.pose() };
+    unsafe {
+        ptr::copy_nonoverlapping(p.covariance.as_ptr(), out, 36);
+    }
+}
+
+/// Write twist linear (x,y,z) + angular (x,y,z).
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_twist(
+    view: *const ros_odometry_t,
+    lx: *mut f64,
+    ly: *mut f64,
+    lz: *mut f64,
+    ax: *mut f64,
+    ay: *mut f64,
+    az: *mut f64,
+) {
+    if view.is_null() {
+        return;
+    }
+    let t = unsafe { (*view).0.twist() };
+    unsafe {
+        if !lx.is_null() {
+            *lx = t.twist.linear.x;
+        }
+        if !ly.is_null() {
+            *ly = t.twist.linear.y;
+        }
+        if !lz.is_null() {
+            *lz = t.twist.linear.z;
+        }
+        if !ax.is_null() {
+            *ax = t.twist.angular.x;
+        }
+        if !ay.is_null() {
+            *ay = t.twist.angular.y;
+        }
+        if !az.is_null() {
+            *az = t.twist.angular.z;
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_odometry_get_twist_covariance(view: *const ros_odometry_t, out: *mut f64) {
+    if view.is_null() || out.is_null() {
+        return;
+    }
+    let t = unsafe { (*view).0.twist() };
+    unsafe {
+        ptr::copy_nonoverlapping(t.covariance.as_ptr(), out, 36);
+    }
+}
+
+// =============================================================================
+// Vibration (buffer-backed)
+// =============================================================================
+
+pub struct ros_vibration_t(edgefirst_msgs::Vibration<&'static [u8]>);
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_from_cdr(data: *const u8, len: usize) -> *mut ros_vibration_t {
+    check_null_ret_null!(data);
+    let slice = unsafe { slice::from_raw_parts(data, len) };
+    match edgefirst_msgs::Vibration::from_cdr(unsafe { erase_lifetime(slice) }) {
+        Ok(v) => Box::into_raw(Box::new(ros_vibration_t(v))),
+        Err(_) => {
+            set_errno(EBADMSG);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_free(view: *mut ros_vibration_t) {
+    if !view.is_null() {
+        unsafe {
+            drop(Box::from_raw(view));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_stamp_sec(view: *const ros_vibration_t) -> i32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().sec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_stamp_nanosec(view: *const ros_vibration_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.stamp().nanosec }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_frame_id(view: *const ros_vibration_t) -> *const c_char {
+    if view.is_null() {
+        return ptr::null();
+    }
+    str_as_c(unsafe { (*view).0.frame_id() })
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_measurement_type(view: *const ros_vibration_t) -> u8 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.measurement_type() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_unit(view: *const ros_vibration_t) -> u8 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.unit() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_band_lower_hz(view: *const ros_vibration_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.band_lower_hz() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_band_upper_hz(view: *const ros_vibration_t) -> f32 {
+    if view.is_null() {
+        return 0.0;
+    }
+    unsafe { (*view).0.band_upper_hz() }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_vibration(
+    view: *const ros_vibration_t,
+    x: *mut f64,
+    y: *mut f64,
+    z: *mut f64,
+) {
+    if view.is_null() {
+        return;
+    }
+    let v = unsafe { (*view).0.vibration() };
+    unsafe {
+        if !x.is_null() {
+            *x = v.x;
+        }
+        if !y.is_null() {
+            *y = v.y;
+        }
+        if !z.is_null() {
+            *z = v.z;
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_clipping_len(view: *const ros_vibration_t) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    unsafe { (*view).0.clipping_len() }
+}
+
+/// Copy up to `cap` clipping counters into `out`; returns the total element count.
+#[no_mangle]
+pub extern "C" fn ros_vibration_get_clipping(
+    view: *const ros_vibration_t,
+    out: *mut u32,
+    cap: usize,
+) -> u32 {
+    if view.is_null() {
+        return 0;
+    }
+    let cl = unsafe { (*view).0.clipping() };
+    let n = cl.len();
+    if !out.is_null() && cap > 0 {
+        let copy_n = n.min(cap);
+        unsafe {
+            ptr::copy_nonoverlapping(cl.as_ptr(), out, copy_n);
+        }
+    }
+    n as u32
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -688,6 +688,63 @@ pub extern "C" fn ros_nav_sat_status_decode(
 // Buffer-backed view types — macro for common boilerplate
 // =============================================================================
 
+/// Decode a little-endian CDR sequence of `f32` in-place into a caller buffer.
+///
+/// `seq_off` points at the 4-byte element count; the elements follow
+/// immediately (no alignment padding: f32 aligns to 4, matching the count).
+/// Returns the element count regardless of `out`/`cap`. Allocation-free.
+fn copy_le_f32_seq(data: &[u8], seq_off: usize, out: *mut f32, cap: usize) -> u32 {
+    let Some(len_end) = seq_off.checked_add(4) else {
+        return 0;
+    };
+    if len_end > data.len() {
+        return 0;
+    }
+    let n = u32::from_le_bytes(data[seq_off..len_end].try_into().unwrap()) as usize;
+    if !out.is_null() && cap > 0 {
+        let copy_n = n.min(cap);
+        let elems = match len_end.checked_add(copy_n.saturating_mul(4)) {
+            Some(e) if e <= data.len() => &data[len_end..e],
+            _ => return n as u32,
+        };
+        for i in 0..copy_n {
+            let b = i * 4;
+            let val = f32::from_le_bytes([elems[b], elems[b + 1], elems[b + 2], elems[b + 3]]);
+            unsafe {
+                *out.add(i) = val;
+            }
+        }
+    }
+    n as u32
+}
+
+/// Decode a little-endian CDR sequence of `u32` in-place into a caller buffer.
+/// Same layout assumptions as [`copy_le_f32_seq`]. Allocation-free.
+fn copy_le_u32_seq(data: &[u8], seq_off: usize, out: *mut u32, cap: usize) -> u32 {
+    let Some(len_end) = seq_off.checked_add(4) else {
+        return 0;
+    };
+    if len_end > data.len() {
+        return 0;
+    }
+    let n = u32::from_le_bytes(data[seq_off..len_end].try_into().unwrap()) as usize;
+    if !out.is_null() && cap > 0 {
+        let copy_n = n.min(cap);
+        let elems = match len_end.checked_add(copy_n.saturating_mul(4)) {
+            Some(e) if e <= data.len() => &data[len_end..e],
+            _ => return n as u32,
+        };
+        for i in 0..copy_n {
+            let b = i * 4;
+            let val = u32::from_le_bytes([elems[b], elems[b + 1], elems[b + 2], elems[b + 3]]);
+            unsafe {
+                *out.add(i) = val;
+            }
+        }
+    }
+    n as u32
+}
+
 /// Helper to return CDR bytes from an owned view (encode result).
 /// Leaks the Vec as a raw pointer; caller must use ros_bytes_free().
 fn return_cdr_bytes(cdr: Vec<u8>, out_bytes: *mut *mut u8, out_len: *mut usize) -> i32 {
@@ -3967,6 +4024,9 @@ pub extern "C" fn ros_battery_state_get_cell_voltage_len(view: *const ros_batter
 }
 
 /// Copy up to `cap` cell voltages into `out`; returns the total element count.
+///
+/// Allocation-free: decodes directly from the backing CDR slice using the
+/// cached sequence offset.
 #[no_mangle]
 pub extern "C" fn ros_battery_state_get_cell_voltage(
     view: *const ros_battery_state_t,
@@ -3976,15 +4036,8 @@ pub extern "C" fn ros_battery_state_get_cell_voltage(
     if view.is_null() {
         return 0;
     }
-    let cells = unsafe { (*view).0.cell_voltage() };
-    let n = cells.len();
-    if !out.is_null() && cap > 0 {
-        let copy_n = n.min(cap);
-        unsafe {
-            ptr::copy_nonoverlapping(cells.as_ptr(), out, copy_n);
-        }
-    }
-    n as u32
+    let msg = unsafe { &(*view).0 };
+    copy_le_f32_seq(msg.as_cdr(), msg.cell_voltage_seq_offset(), out, cap)
 }
 
 #[no_mangle]
@@ -3997,6 +4050,10 @@ pub extern "C" fn ros_battery_state_get_cell_temperature_len(
     unsafe { (*view).0.cell_temperature_len() }
 }
 
+/// Copy up to `cap` cell temperatures into `out`; returns the total element count.
+///
+/// Allocation-free: decodes directly from the backing CDR slice using the
+/// cached sequence offset.
 #[no_mangle]
 pub extern "C" fn ros_battery_state_get_cell_temperature(
     view: *const ros_battery_state_t,
@@ -4006,15 +4063,8 @@ pub extern "C" fn ros_battery_state_get_cell_temperature(
     if view.is_null() {
         return 0;
     }
-    let cells = unsafe { (*view).0.cell_temperature() };
-    let n = cells.len();
-    if !out.is_null() && cap > 0 {
-        let copy_n = n.min(cap);
-        unsafe {
-            ptr::copy_nonoverlapping(cells.as_ptr(), out, copy_n);
-        }
-    }
-    n as u32
+    let msg = unsafe { &(*view).0 };
+    copy_le_f32_seq(msg.as_cdr(), msg.cell_temperature_seq_offset(), out, cap)
 }
 
 #[no_mangle]
@@ -4315,6 +4365,9 @@ pub extern "C" fn ros_vibration_get_clipping_len(view: *const ros_vibration_t) -
 }
 
 /// Copy up to `cap` clipping counters into `out`; returns the total element count.
+///
+/// Allocation-free: decodes directly from the backing CDR slice using the
+/// cached sequence offset.
 #[no_mangle]
 pub extern "C" fn ros_vibration_get_clipping(
     view: *const ros_vibration_t,
@@ -4324,13 +4377,6 @@ pub extern "C" fn ros_vibration_get_clipping(
     if view.is_null() {
         return 0;
     }
-    let cl = unsafe { (*view).0.clipping() };
-    let n = cl.len();
-    if !out.is_null() && cap > 0 {
-        let copy_n = n.min(cap);
-        unsafe {
-            ptr::copy_nonoverlapping(cl.as_ptr(), out, copy_n);
-        }
-    }
-    n as u32
+    let msg = unsafe { &(*view).0 };
+    copy_le_u32_seq(msg.as_cdr(), msg.clipping_seq_offset(), out, cap)
 }

--- a/src/geometry_msgs.rs
+++ b/src/geometry_msgs.rs
@@ -4,7 +4,8 @@
 //! ROS 2 `geometry_msgs` message types.
 //!
 //! CdrFixed: `Vector3`, `Point`, `Point32`, `Quaternion`, `Pose`,
-//! `Pose2D`, `Transform`, `Accel`, `Twist`, `Inertia`
+//! `Pose2D`, `Transform`, `Accel`, `Twist`, `Inertia`,
+//! `PoseWithCovariance`, `TwistWithCovariance`
 //!
 //! Buffer-backed (stamped wrappers): `AccelStamped`, `TwistStamped`,
 //! `InertiaStamped`, `PointStamped`, `TransformStamped`
@@ -73,6 +74,20 @@ pub struct Accel {
 pub struct Twist {
     pub linear: Vector3,
     pub angular: Vector3,
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub struct PoseWithCovariance {
+    pub pose: Pose,
+    /// Row-major 6×6 covariance of (x, y, z, rotX, rotY, rotZ).
+    pub covariance: [f64; 36],
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub struct TwistWithCovariance {
+    pub twist: Twist,
+    /// Row-major 6×6 covariance of (x, y, z, rotX, rotY, rotZ).
+    pub covariance: [f64; 36],
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
@@ -266,6 +281,54 @@ impl CdrFixed for Twist {
     fn size_cdr(sizer: &mut CdrSizer) {
         Vector3::size_cdr(sizer);
         Vector3::size_cdr(sizer);
+    }
+}
+
+impl CdrFixed for PoseWithCovariance {
+    const CDR_SIZE: usize = 56 + 36 * 8; // Pose(56) + [f64; 36](288) = 344
+    fn read_cdr(cursor: &mut CdrCursor<'_>) -> Result<Self, CdrError> {
+        let pose = Pose::read_cdr(cursor)?;
+        let mut covariance = [0.0_f64; 36];
+        for slot in covariance.iter_mut() {
+            *slot = cursor.read_f64()?;
+        }
+        Ok(PoseWithCovariance { pose, covariance })
+    }
+    fn write_cdr(&self, writer: &mut CdrWriter<'_>) {
+        self.pose.write_cdr(writer);
+        for v in &self.covariance {
+            writer.write_f64(*v);
+        }
+    }
+    fn size_cdr(sizer: &mut CdrSizer) {
+        Pose::size_cdr(sizer);
+        for _ in 0..36 {
+            sizer.size_f64();
+        }
+    }
+}
+
+impl CdrFixed for TwistWithCovariance {
+    const CDR_SIZE: usize = 48 + 36 * 8; // Twist(48) + [f64; 36](288) = 336
+    fn read_cdr(cursor: &mut CdrCursor<'_>) -> Result<Self, CdrError> {
+        let twist = Twist::read_cdr(cursor)?;
+        let mut covariance = [0.0_f64; 36];
+        for slot in covariance.iter_mut() {
+            *slot = cursor.read_f64()?;
+        }
+        Ok(TwistWithCovariance { twist, covariance })
+    }
+    fn write_cdr(&self, writer: &mut CdrWriter<'_>) {
+        self.twist.write_cdr(writer);
+        for v in &self.covariance {
+            writer.write_f64(*v);
+        }
+    }
+    fn size_cdr(sizer: &mut CdrSizer) {
+        Twist::size_cdr(sizer);
+        for _ in 0..36 {
+            sizer.size_f64();
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub mod foxglove_msgs;
 
 /// ROS 2 geometry message types.
 pub mod geometry_msgs;
+/// ROS 2 navigation message types.
+pub mod nav_msgs;
 /// ROS 2 sensor message types.
 pub mod sensor_msgs;
 /// ROS 2 standard message types (Header, ColorRGBA).

--- a/src/nav_msgs.rs
+++ b/src/nav_msgs.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 Au-Zone Technologies. All Rights Reserved.
+
+//! ROS 2 `nav_msgs` message types.
+//!
+//! Buffer-backed: `Odometry`
+
+use crate::builtin_interfaces::Time;
+use crate::cdr::*;
+use crate::geometry_msgs::{PoseWithCovariance, TwistWithCovariance};
+use crate::std_msgs::Header;
+
+// ── Odometry<B> ─────────────────────────────────────────────────────
+//
+// CDR layout: Header → pre, then:
+//   string child_frame_id → offsets[0] (start of child_frame_id)
+//   pad to 8 → offsets[1] (start of PoseWithCovariance)
+//   PoseWithCovariance pose (344 bytes, all f64-aligned)
+//   TwistWithCovariance twist (336 bytes, all f64-aligned)
+//
+// offsets[1] is captured from the cursor after aligning to 8 because
+// `child_frame_id` is a variable-length string; PoseWithCovariance
+// starts with a Point (f64 first), so an explicit align-to-8 is needed.
+
+pub struct Odometry<B> {
+    buf: B,
+    offsets: [usize; 2],
+}
+
+impl<B: AsRef<[u8]>> Odometry<B> {
+    pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
+        let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
+        let pre = header.end_offset();
+        let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        let o0 = c.offset();
+        let _ = c.read_string()?; // child_frame_id
+        c.align(8);
+        let o1 = c.offset();
+        PoseWithCovariance::read_cdr(&mut c)?;
+        TwistWithCovariance::read_cdr(&mut c)?;
+        Ok(Odometry {
+            offsets: [o0, o1],
+            buf,
+        })
+    }
+
+    /// Returns a `Header` view by re-parsing the CDR buffer prefix.
+    pub fn header(&self) -> Header<&[u8]> {
+        Header::from_cdr(self.buf.as_ref()).expect("header bytes validated during from_cdr")
+    }
+    pub fn stamp(&self) -> Time {
+        rd_time(self.buf.as_ref(), CDR_HEADER_SIZE)
+    }
+    pub fn frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
+    }
+    pub fn child_frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), self.offsets[0]).0
+    }
+    pub fn pose(&self) -> PoseWithCovariance {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[1]);
+        PoseWithCovariance::read_cdr(&mut c).expect("pose validated during from_cdr")
+    }
+    pub fn twist(&self) -> TwistWithCovariance {
+        // PoseWithCovariance::CDR_SIZE is 344 bytes, all f64-aligned,
+        // so the twist starts exactly offsets[1] + 344.
+        let mut c = CdrCursor::resume(
+            self.buf.as_ref(),
+            self.offsets[1] + PoseWithCovariance::CDR_SIZE,
+        );
+        TwistWithCovariance::read_cdr(&mut c).expect("twist validated during from_cdr")
+    }
+    pub fn as_cdr(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+    pub fn to_cdr(&self) -> Vec<u8> {
+        self.buf.as_ref().to_vec()
+    }
+}
+
+impl Odometry<Vec<u8>> {
+    pub fn new(
+        stamp: Time,
+        frame_id: &str,
+        child_frame_id: &str,
+        pose: PoseWithCovariance,
+        twist: TwistWithCovariance,
+    ) -> Result<Self, CdrError> {
+        let mut sizer = CdrSizer::new();
+        Time::size_cdr(&mut sizer);
+        sizer.size_string(frame_id);
+        let o0 = sizer.offset();
+        sizer.size_string(child_frame_id);
+        sizer.align(8);
+        let o1 = sizer.offset();
+        PoseWithCovariance::size_cdr(&mut sizer);
+        TwistWithCovariance::size_cdr(&mut sizer);
+
+        let mut buf = vec![0u8; sizer.size()];
+        let mut w = CdrWriter::new(&mut buf)?;
+        stamp.write_cdr(&mut w);
+        w.write_string(frame_id);
+        w.write_string(child_frame_id);
+        pose.write_cdr(&mut w);
+        twist.write_cdr(&mut w);
+        w.finish()?;
+
+        Ok(Odometry {
+            offsets: [o0, o1],
+            buf,
+        })
+    }
+
+    pub fn into_cdr(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+// ── Registry ────────────────────────────────────────────────────────
+
+/// Check if a type name is supported by this module.
+pub fn is_type_supported(type_name: &str) -> bool {
+    matches!(type_name, "Odometry")
+}
+
+/// List all type schema names in this module.
+pub fn list_types() -> &'static [&'static str] {
+    &["nav_msgs/msg/Odometry"]
+}

--- a/src/nav_msgs.rs
+++ b/src/nav_msgs.rs
@@ -15,16 +15,19 @@ use crate::std_msgs::Header;
 // CDR layout: Header → pre, then:
 //   string child_frame_id → offsets[0] (start of child_frame_id)
 //   pad to 8 → offsets[1] (start of PoseWithCovariance)
-//   PoseWithCovariance pose (344 bytes, all f64-aligned)
-//   TwistWithCovariance twist (336 bytes, all f64-aligned)
+//   PoseWithCovariance pose  → offsets[2] captured after pose decode,
+//                              i.e. start of TwistWithCovariance
+//   TwistWithCovariance twist
 //
 // offsets[1] is captured from the cursor after aligning to 8 because
 // `child_frame_id` is a variable-length string; PoseWithCovariance
 // starts with a Point (f64 first), so an explicit align-to-8 is needed.
+// offsets[2] is captured from the cursor after pose decode so `twist()`
+// doesn't depend on `PoseWithCovariance::CDR_SIZE` layout arithmetic.
 
 pub struct Odometry<B> {
     buf: B,
-    offsets: [usize; 2],
+    offsets: [usize; 3],
 }
 
 impl<B: AsRef<[u8]>> Odometry<B> {
@@ -37,9 +40,10 @@ impl<B: AsRef<[u8]>> Odometry<B> {
         c.align(8);
         let o1 = c.offset();
         PoseWithCovariance::read_cdr(&mut c)?;
+        let o2 = c.offset();
         TwistWithCovariance::read_cdr(&mut c)?;
         Ok(Odometry {
-            offsets: [o0, o1],
+            offsets: [o0, o1, o2],
             buf,
         })
     }
@@ -62,12 +66,7 @@ impl<B: AsRef<[u8]>> Odometry<B> {
         PoseWithCovariance::read_cdr(&mut c).expect("pose validated during from_cdr")
     }
     pub fn twist(&self) -> TwistWithCovariance {
-        // PoseWithCovariance::CDR_SIZE is 344 bytes, all f64-aligned,
-        // so the twist starts exactly offsets[1] + 344.
-        let mut c = CdrCursor::resume(
-            self.buf.as_ref(),
-            self.offsets[1] + PoseWithCovariance::CDR_SIZE,
-        );
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[2]);
         TwistWithCovariance::read_cdr(&mut c).expect("twist validated during from_cdr")
     }
     pub fn as_cdr(&self) -> &[u8] {
@@ -94,6 +93,7 @@ impl Odometry<Vec<u8>> {
         sizer.align(8);
         let o1 = sizer.offset();
         PoseWithCovariance::size_cdr(&mut sizer);
+        let o2 = sizer.offset();
         TwistWithCovariance::size_cdr(&mut sizer);
 
         let mut buf = vec![0u8; sizer.size()];
@@ -106,7 +106,7 @@ impl Odometry<Vec<u8>> {
         w.finish()?;
 
         Ok(Odometry {
-            offsets: [o0, o1],
+            offsets: [o0, o1, o2],
             buf,
         })
     }

--- a/src/schema_registry.rs
+++ b/src/schema_registry.rs
@@ -23,7 +23,8 @@
 //! ```
 
 use crate::{
-    builtin_interfaces, edgefirst_msgs, foxglove_msgs, geometry_msgs, sensor_msgs, std_msgs,
+    builtin_interfaces, edgefirst_msgs, foxglove_msgs, geometry_msgs, nav_msgs, sensor_msgs,
+    std_msgs,
 };
 
 /// Trait for types that have a schema name.
@@ -86,6 +87,7 @@ pub fn is_supported(schema: &str) -> bool {
         "builtin_interfaces" => builtin_interfaces::is_type_supported(type_name),
         "std_msgs" => std_msgs::is_type_supported(type_name),
         "geometry_msgs" => geometry_msgs::is_type_supported(type_name),
+        "nav_msgs" => nav_msgs::is_type_supported(type_name),
         "sensor_msgs" => sensor_msgs::is_type_supported(type_name),
         "foxglove_msgs" => foxglove_msgs::is_type_supported(type_name),
         "edgefirst_msgs" => edgefirst_msgs::is_type_supported(type_name),
@@ -102,6 +104,7 @@ pub fn list_schemas() -> Vec<&'static str> {
     schemas.extend(builtin_interfaces::list_types().iter().copied());
     schemas.extend(std_msgs::list_types().iter().copied());
     schemas.extend(geometry_msgs::list_types().iter().copied());
+    schemas.extend(nav_msgs::list_types().iter().copied());
     schemas.extend(sensor_msgs::list_types().iter().copied());
     schemas.extend(foxglove_msgs::list_types().iter().copied());
     schemas.extend(edgefirst_msgs::list_types().iter().copied());

--- a/src/sensor_msgs/mod.rs
+++ b/src/sensor_msgs/mod.rs
@@ -1480,12 +1480,15 @@ impl<B: AsRef<[u8]>> BatteryState<B> {
         c.read_u8()?; // power_supply_technology
         c.read_bool()?; // present
         let o1 = c.offset();
-        let cv_len = c.read_u32()? as usize;
+        // f32 = 4 bytes each; hardening check against pathological counts.
+        let raw = c.read_u32()?;
+        let cv_len = c.check_seq_count(raw, 4)?;
         for _ in 0..cv_len {
             c.read_f32()?;
         }
         let o2 = c.offset();
-        let ct_len = c.read_u32()? as usize;
+        let raw = c.read_u32()?;
+        let ct_len = c.check_seq_count(raw, 4)?;
         for _ in 0..ct_len {
             c.read_f32()?;
         }

--- a/src/sensor_msgs/mod.rs
+++ b/src/sensor_msgs/mod.rs
@@ -1547,6 +1547,11 @@ impl<B: AsRef<[u8]>> BatteryState<B> {
     pub fn cell_voltage_len(&self) -> u32 {
         rd_u32(self.buf.as_ref(), self.offsets[1])
     }
+    /// Byte offset of the `cell_voltage` sequence (u32 count, then elements).
+    /// Exposed for allocation-free decoders (e.g. FFI).
+    pub fn cell_voltage_seq_offset(&self) -> usize {
+        self.offsets[1]
+    }
     pub fn cell_voltage(&self) -> Vec<f32> {
         let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[1]);
         let n = c
@@ -1563,6 +1568,11 @@ impl<B: AsRef<[u8]>> BatteryState<B> {
     }
     pub fn cell_temperature_len(&self) -> u32 {
         rd_u32(self.buf.as_ref(), self.offsets[2])
+    }
+    /// Byte offset of the `cell_temperature` sequence (u32 count, then elements).
+    /// Exposed for allocation-free decoders (e.g. FFI).
+    pub fn cell_temperature_seq_offset(&self) -> usize {
+        self.offsets[2]
     }
     pub fn cell_temperature(&self) -> Vec<f32> {
         let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[2]);

--- a/src/sensor_msgs/mod.rs
+++ b/src/sensor_msgs/mod.rs
@@ -1174,36 +1174,545 @@ pub mod point_field {
     pub const FLOAT64: u8 = 8;
 }
 
+// ── MagneticField<B> ────────────────────────────────────────────────
+//
+// CDR layout: Header → offsets[0] (start of magnetic_field, 8-aligned),
+//   Vector3 magnetic_field (24 bytes), float64[9] covariance (72 bytes).
+// offsets[0] is captured from the cursor after Header+align(8) to avoid
+// the EDGEAI-1243 class of bug.
+
+pub struct MagneticField<B> {
+    buf: B,
+    offsets: [usize; 1],
+}
+
+impl<B: AsRef<[u8]>> MagneticField<B> {
+    pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
+        let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
+        let pre = header.end_offset();
+        let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        c.align(8);
+        let o0 = c.offset();
+        Vector3::read_cdr(&mut c)?;
+        read_f64_array9(&mut c)?;
+        Ok(MagneticField { offsets: [o0], buf })
+    }
+
+    /// Returns a `Header` view by re-parsing the CDR buffer prefix.
+    pub fn header(&self) -> Header<&[u8]> {
+        Header::from_cdr(self.buf.as_ref()).expect("header bytes validated during from_cdr")
+    }
+    pub fn stamp(&self) -> Time {
+        rd_time(self.buf.as_ref(), CDR_HEADER_SIZE)
+    }
+    pub fn frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
+    }
+    pub fn magnetic_field(&self) -> Vector3 {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[0]);
+        Vector3::read_cdr(&mut c).expect("magnetic_field validated during from_cdr")
+    }
+    pub fn magnetic_field_covariance(&self) -> [f64; 9] {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[0] + 24);
+        read_f64_array9(&mut c).expect("covariance validated during from_cdr")
+    }
+    pub fn as_cdr(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+    pub fn to_cdr(&self) -> Vec<u8> {
+        self.buf.as_ref().to_vec()
+    }
+}
+
+impl MagneticField<Vec<u8>> {
+    pub fn new(
+        stamp: Time,
+        frame_id: &str,
+        magnetic_field: Vector3,
+        magnetic_field_covariance: [f64; 9],
+    ) -> Result<Self, CdrError> {
+        let mut sizer = CdrSizer::new();
+        Time::size_cdr(&mut sizer);
+        sizer.size_string(frame_id);
+        sizer.align(8);
+        let o0 = sizer.offset();
+        Vector3::size_cdr(&mut sizer);
+        size_f64_array9(&mut sizer);
+
+        let mut buf = vec![0u8; sizer.size()];
+        let mut w = CdrWriter::new(&mut buf)?;
+        stamp.write_cdr(&mut w);
+        w.write_string(frame_id);
+        magnetic_field.write_cdr(&mut w);
+        write_f64_array9(&mut w, &magnetic_field_covariance);
+        w.finish()?;
+
+        Ok(MagneticField { offsets: [o0], buf })
+    }
+
+    pub fn into_cdr(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+// ── FluidPressure<B> ────────────────────────────────────────────────
+//
+// CDR layout: Header → offsets[0] (start of fluid_pressure, 8-aligned),
+//   float64 fluid_pressure (8 bytes), float64 variance (8 bytes).
+
+pub struct FluidPressure<B> {
+    buf: B,
+    offsets: [usize; 1],
+}
+
+impl<B: AsRef<[u8]>> FluidPressure<B> {
+    pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
+        let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
+        let pre = header.end_offset();
+        let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        c.align(8);
+        let o0 = c.offset();
+        c.read_f64()?; // fluid_pressure
+        c.read_f64()?; // variance
+        Ok(FluidPressure { offsets: [o0], buf })
+    }
+
+    pub fn header(&self) -> Header<&[u8]> {
+        Header::from_cdr(self.buf.as_ref()).expect("header bytes validated during from_cdr")
+    }
+    pub fn stamp(&self) -> Time {
+        rd_time(self.buf.as_ref(), CDR_HEADER_SIZE)
+    }
+    pub fn frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
+    }
+    pub fn fluid_pressure(&self) -> f64 {
+        rd_f64(self.buf.as_ref(), self.offsets[0])
+    }
+    pub fn variance(&self) -> f64 {
+        rd_f64(self.buf.as_ref(), self.offsets[0] + 8)
+    }
+    pub fn as_cdr(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+    pub fn to_cdr(&self) -> Vec<u8> {
+        self.buf.as_ref().to_vec()
+    }
+}
+
+impl FluidPressure<Vec<u8>> {
+    pub fn new(
+        stamp: Time,
+        frame_id: &str,
+        fluid_pressure: f64,
+        variance: f64,
+    ) -> Result<Self, CdrError> {
+        let mut sizer = CdrSizer::new();
+        Time::size_cdr(&mut sizer);
+        sizer.size_string(frame_id);
+        sizer.align(8);
+        let o0 = sizer.offset();
+        sizer.size_f64();
+        sizer.size_f64();
+
+        let mut buf = vec![0u8; sizer.size()];
+        let mut w = CdrWriter::new(&mut buf)?;
+        stamp.write_cdr(&mut w);
+        w.write_string(frame_id);
+        w.write_f64(fluid_pressure);
+        w.write_f64(variance);
+        w.finish()?;
+
+        Ok(FluidPressure { offsets: [o0], buf })
+    }
+
+    pub fn into_cdr(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+// ── Temperature<B> ──────────────────────────────────────────────────
+//
+// CDR layout: Header → offsets[0] (start of temperature, 8-aligned),
+//   float64 temperature (8 bytes), float64 variance (8 bytes).
+
+pub struct Temperature<B> {
+    buf: B,
+    offsets: [usize; 1],
+}
+
+impl<B: AsRef<[u8]>> Temperature<B> {
+    pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
+        let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
+        let pre = header.end_offset();
+        let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        c.align(8);
+        let o0 = c.offset();
+        c.read_f64()?; // temperature
+        c.read_f64()?; // variance
+        Ok(Temperature { offsets: [o0], buf })
+    }
+
+    pub fn header(&self) -> Header<&[u8]> {
+        Header::from_cdr(self.buf.as_ref()).expect("header bytes validated during from_cdr")
+    }
+    pub fn stamp(&self) -> Time {
+        rd_time(self.buf.as_ref(), CDR_HEADER_SIZE)
+    }
+    pub fn frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
+    }
+    pub fn temperature(&self) -> f64 {
+        rd_f64(self.buf.as_ref(), self.offsets[0])
+    }
+    pub fn variance(&self) -> f64 {
+        rd_f64(self.buf.as_ref(), self.offsets[0] + 8)
+    }
+    pub fn as_cdr(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+    pub fn to_cdr(&self) -> Vec<u8> {
+        self.buf.as_ref().to_vec()
+    }
+}
+
+impl Temperature<Vec<u8>> {
+    pub fn new(
+        stamp: Time,
+        frame_id: &str,
+        temperature: f64,
+        variance: f64,
+    ) -> Result<Self, CdrError> {
+        let mut sizer = CdrSizer::new();
+        Time::size_cdr(&mut sizer);
+        sizer.size_string(frame_id);
+        sizer.align(8);
+        let o0 = sizer.offset();
+        sizer.size_f64();
+        sizer.size_f64();
+
+        let mut buf = vec![0u8; sizer.size()];
+        let mut w = CdrWriter::new(&mut buf)?;
+        stamp.write_cdr(&mut w);
+        w.write_string(frame_id);
+        w.write_f64(temperature);
+        w.write_f64(variance);
+        w.finish()?;
+
+        Ok(Temperature { offsets: [o0], buf })
+    }
+
+    pub fn into_cdr(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+// ── BatteryState<B> ─────────────────────────────────────────────────
+//
+// CDR layout: Header → offsets[0] (start of fixed scalars, 4-aligned),
+//   float32 voltage, temperature, current, charge, capacity,
+//   design_capacity, percentage (7×4 = 28 bytes),
+//   uint8 power_supply_status, power_supply_health,
+//   power_supply_technology, bool present (4 bytes, no trailing pad
+//   until next 4-aligned field),
+//   uint32 count + float32[] cell_voltage → offsets[1] (byte index of
+//     the seq count u32),
+//   uint32 count + float32[] cell_temperature → offsets[2],
+//   string location → offsets[3],
+//   string serial_number → offsets[4].
+
+/// `POWER_SUPPLY_STATUS_*` values for [`BatteryState::power_supply_status`].
+pub mod power_supply_status {
+    pub const UNKNOWN: u8 = 0;
+    pub const CHARGING: u8 = 1;
+    pub const DISCHARGING: u8 = 2;
+    pub const NOT_CHARGING: u8 = 3;
+    pub const FULL: u8 = 4;
+}
+
+/// `POWER_SUPPLY_HEALTH_*` values for [`BatteryState::power_supply_health`].
+pub mod power_supply_health {
+    pub const UNKNOWN: u8 = 0;
+    pub const GOOD: u8 = 1;
+    pub const OVERHEAT: u8 = 2;
+    pub const DEAD: u8 = 3;
+    pub const OVERVOLTAGE: u8 = 4;
+    pub const UNSPEC_FAILURE: u8 = 5;
+    pub const COLD: u8 = 6;
+    pub const WATCHDOG_TIMER_EXPIRE: u8 = 7;
+    pub const SAFETY_TIMER_EXPIRE: u8 = 8;
+}
+
+/// `POWER_SUPPLY_TECHNOLOGY_*` values for [`BatteryState::power_supply_technology`].
+pub mod power_supply_technology {
+    pub const UNKNOWN: u8 = 0;
+    pub const NIMH: u8 = 1;
+    pub const LION: u8 = 2;
+    pub const LIPO: u8 = 3;
+    pub const LIFE: u8 = 4;
+    pub const NICD: u8 = 5;
+    pub const LIMN: u8 = 6;
+}
+
+pub struct BatteryState<B> {
+    buf: B,
+    // [0]: voltage start (4-aligned after Header).
+    // [1]: start of cell_voltage seq-count u32.
+    // [2]: start of cell_temperature seq-count u32.
+    // [3]: start of location string.
+    // [4]: start of serial_number string.
+    offsets: [usize; 5],
+}
+
+impl<B: AsRef<[u8]>> BatteryState<B> {
+    pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
+        let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
+        let pre = header.end_offset();
+        let mut c = CdrCursor::resume(buf.as_ref(), pre);
+        c.align(4);
+        let o0 = c.offset();
+        // Seven f32 scalars
+        for _ in 0..7 {
+            c.read_f32()?;
+        }
+        c.read_u8()?; // power_supply_status
+        c.read_u8()?; // power_supply_health
+        c.read_u8()?; // power_supply_technology
+        c.read_bool()?; // present
+        let o1 = c.offset();
+        let cv_len = c.read_u32()? as usize;
+        for _ in 0..cv_len {
+            c.read_f32()?;
+        }
+        let o2 = c.offset();
+        let ct_len = c.read_u32()? as usize;
+        for _ in 0..ct_len {
+            c.read_f32()?;
+        }
+        let o3 = c.offset();
+        c.read_string()?; // location
+        let o4 = c.offset();
+        c.read_string()?; // serial_number
+        Ok(BatteryState {
+            offsets: [o0, o1, o2, o3, o4],
+            buf,
+        })
+    }
+
+    pub fn header(&self) -> Header<&[u8]> {
+        Header::from_cdr(self.buf.as_ref()).expect("header bytes validated during from_cdr")
+    }
+    pub fn stamp(&self) -> Time {
+        rd_time(self.buf.as_ref(), CDR_HEADER_SIZE)
+    }
+    pub fn frame_id(&self) -> &str {
+        rd_string(self.buf.as_ref(), CDR_HEADER_SIZE + 8).0
+    }
+    pub fn voltage(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0])
+    }
+    pub fn temperature(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 4)
+    }
+    pub fn current(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 8)
+    }
+    pub fn charge(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 12)
+    }
+    pub fn capacity(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 16)
+    }
+    pub fn design_capacity(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 20)
+    }
+    pub fn percentage(&self) -> f32 {
+        rd_f32(self.buf.as_ref(), self.offsets[0] + 24)
+    }
+    pub fn power_supply_status(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0] + 28)
+    }
+    pub fn power_supply_health(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0] + 29)
+    }
+    pub fn power_supply_technology(&self) -> u8 {
+        rd_u8(self.buf.as_ref(), self.offsets[0] + 30)
+    }
+    pub fn present(&self) -> bool {
+        rd_bool(self.buf.as_ref(), self.offsets[0] + 31)
+    }
+    pub fn cell_voltage_len(&self) -> u32 {
+        rd_u32(self.buf.as_ref(), self.offsets[1])
+    }
+    pub fn cell_voltage(&self) -> Vec<f32> {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[1]);
+        let n = c
+            .read_u32()
+            .expect("cell_voltage length validated during from_cdr") as usize;
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            out.push(
+                c.read_f32()
+                    .expect("cell_voltage element validated during from_cdr"),
+            );
+        }
+        out
+    }
+    pub fn cell_temperature_len(&self) -> u32 {
+        rd_u32(self.buf.as_ref(), self.offsets[2])
+    }
+    pub fn cell_temperature(&self) -> Vec<f32> {
+        let mut c = CdrCursor::resume(self.buf.as_ref(), self.offsets[2]);
+        let n = c
+            .read_u32()
+            .expect("cell_temperature length validated during from_cdr") as usize;
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            out.push(
+                c.read_f32()
+                    .expect("cell_temperature element validated during from_cdr"),
+            );
+        }
+        out
+    }
+    pub fn location(&self) -> &str {
+        rd_string(self.buf.as_ref(), self.offsets[3]).0
+    }
+    pub fn serial_number(&self) -> &str {
+        rd_string(self.buf.as_ref(), self.offsets[4]).0
+    }
+    pub fn as_cdr(&self) -> &[u8] {
+        self.buf.as_ref()
+    }
+    pub fn to_cdr(&self) -> Vec<u8> {
+        self.buf.as_ref().to_vec()
+    }
+}
+
+impl BatteryState<Vec<u8>> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        stamp: Time,
+        frame_id: &str,
+        voltage: f32,
+        temperature: f32,
+        current: f32,
+        charge: f32,
+        capacity: f32,
+        design_capacity: f32,
+        percentage: f32,
+        power_supply_status: u8,
+        power_supply_health: u8,
+        power_supply_technology: u8,
+        present: bool,
+        cell_voltage: &[f32],
+        cell_temperature: &[f32],
+        location: &str,
+        serial_number: &str,
+    ) -> Result<Self, CdrError> {
+        let mut sizer = CdrSizer::new();
+        Time::size_cdr(&mut sizer);
+        sizer.size_string(frame_id);
+        sizer.align(4);
+        let o0 = sizer.offset();
+        for _ in 0..7 {
+            sizer.size_f32();
+        }
+        sizer.size_u8();
+        sizer.size_u8();
+        sizer.size_u8();
+        sizer.size_bool();
+        let o1 = sizer.offset();
+        sizer.size_u32();
+        for _ in cell_voltage {
+            sizer.size_f32();
+        }
+        let o2 = sizer.offset();
+        sizer.size_u32();
+        for _ in cell_temperature {
+            sizer.size_f32();
+        }
+        let o3 = sizer.offset();
+        sizer.size_string(location);
+        let o4 = sizer.offset();
+        sizer.size_string(serial_number);
+
+        let mut buf = vec![0u8; sizer.size()];
+        let mut w = CdrWriter::new(&mut buf)?;
+        stamp.write_cdr(&mut w);
+        w.write_string(frame_id);
+        w.write_f32(voltage);
+        w.write_f32(temperature);
+        w.write_f32(current);
+        w.write_f32(charge);
+        w.write_f32(capacity);
+        w.write_f32(design_capacity);
+        w.write_f32(percentage);
+        w.write_u8(power_supply_status);
+        w.write_u8(power_supply_health);
+        w.write_u8(power_supply_technology);
+        w.write_bool(present);
+        w.write_u32(cell_voltage.len() as u32);
+        for v in cell_voltage {
+            w.write_f32(*v);
+        }
+        w.write_u32(cell_temperature.len() as u32);
+        for v in cell_temperature {
+            w.write_f32(*v);
+        }
+        w.write_string(location);
+        w.write_string(serial_number);
+        w.finish()?;
+
+        Ok(BatteryState {
+            offsets: [o0, o1, o2, o3, o4],
+            buf,
+        })
+    }
+
+    pub fn into_cdr(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
 // ── Registry ────────────────────────────────────────────────────────
 
 /// Check if a type name is supported by this module.
 pub fn is_type_supported(type_name: &str) -> bool {
     matches!(
         type_name,
-        "CameraInfo"
+        "BatteryState"
+            | "CameraInfo"
             | "CompressedImage"
+            | "FluidPressure"
             | "Image"
             | "Imu"
+            | "MagneticField"
             | "NavSatFix"
             | "NavSatStatus"
             | "PointCloud2"
             | "PointField"
             | "RegionOfInterest"
+            | "Temperature"
     )
 }
 
 /// List all type schema names in this module.
 pub fn list_types() -> &'static [&'static str] {
     &[
+        "sensor_msgs/msg/BatteryState",
         "sensor_msgs/msg/CameraInfo",
         "sensor_msgs/msg/CompressedImage",
+        "sensor_msgs/msg/FluidPressure",
         "sensor_msgs/msg/Image",
         "sensor_msgs/msg/Imu",
+        "sensor_msgs/msg/MagneticField",
         "sensor_msgs/msg/NavSatFix",
         "sensor_msgs/msg/NavSatStatus",
         "sensor_msgs/msg/PointCloud2",
         "sensor_msgs/msg/PointField",
         "sensor_msgs/msg/RegionOfInterest",
+        "sensor_msgs/msg/Temperature",
     ]
 }
 

--- a/testdata/cdr/edgefirst_msgs/Vibration.cdr
+++ b/testdata/cdr/edgefirst_msgs/Vibration.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a181ebe5eb84ff167fc86595c034924ccd2c1425fb5fdc9a804b1d6b7b8c41ba
+size 84

--- a/testdata/cdr/edgefirst_msgs/Vibration.cdr
+++ b/testdata/cdr/edgefirst_msgs/Vibration.cdr
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a181ebe5eb84ff167fc86595c034924ccd2c1425fb5fdc9a804b1d6b7b8c41ba
-size 84
+oid sha256:5fc865bbc1f6cc7d11dc7d97d55db73683357715ea4b83eb58c4c576af32fbc7
+size 80

--- a/testdata/cdr/geometry_msgs/PoseWithCovariance.cdr
+++ b/testdata/cdr/geometry_msgs/PoseWithCovariance.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88219918ea7dcc7ff49ab418aae28e7abfddd48bccb9506d9915cc5f82e53038
+size 348

--- a/testdata/cdr/geometry_msgs/TwistWithCovariance.cdr
+++ b/testdata/cdr/geometry_msgs/TwistWithCovariance.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02ddb81b8a767400a0b05b353bf44a4e69fc188c63a40fab7c223f7ac4348459
+size 340

--- a/testdata/cdr/nav_msgs/Odometry.cdr
+++ b/testdata/cdr/nav_msgs/Odometry.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2635d30bf06abd9ee3b2189870710d06f2a85c287a5a08c1a286c5784f3672f
+size 724

--- a/testdata/cdr/sensor_msgs/BatteryState.cdr
+++ b/testdata/cdr/sensor_msgs/BatteryState.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3b2351d7c2916e3522ed718f86b6148c39d7dac5383abe07022472545037f21
+size 122

--- a/testdata/cdr/sensor_msgs/FluidPressure.cdr
+++ b/testdata/cdr/sensor_msgs/FluidPressure.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51353ff4fde1b5c0e4aecb6f9408d8250eb74e823c5359bb6e4b1bc0b15c2bea
+size 44

--- a/testdata/cdr/sensor_msgs/MagneticField.cdr
+++ b/testdata/cdr/sensor_msgs/MagneticField.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b2a3d20861439512846ab92e41baa1e3d9849887c20d04e351a9b8c882ff2e1
+size 124

--- a/testdata/cdr/sensor_msgs/Temperature.cdr
+++ b/testdata/cdr/sensor_msgs/Temperature.cdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3bd11ec0e56684e0bdd91e33aaeb19bede7555ea40d879886fc0fa95179b71a
+size 44

--- a/tests/c/test_edgefirst_msgs.c
+++ b/tests/c/test_edgefirst_msgs.c
@@ -1140,3 +1140,61 @@ Test(edgefirst_msgs, camera_frame_empty_metadata_only) {
     ros_camera_frame_free(h);
     free(b);
 }
+
+// ============================================================================
+// Vibration Tests (TOP2-770)
+// ============================================================================
+
+Test(edgefirst_msgs, vibration_from_golden_fixture) {
+    size_t len = 0;
+    uint8_t *b = load_fixture("testdata/cdr/edgefirst_msgs/Vibration.cdr", &len);
+    cr_assert_not_null(b, "failed to load Vibration fixture");
+    ros_vibration_t *v = ros_vibration_from_cdr(b, len);
+    cr_assert_not_null(v);
+    cr_assert_str_eq(ros_vibration_get_frame_id(v), "test_frame");
+    cr_assert_eq(ros_vibration_get_measurement_type(v),
+                 ROS_VIBRATION_MEASUREMENT_RMS);
+    cr_assert_eq(ros_vibration_get_unit(v), ROS_VIBRATION_UNIT_ACCEL_M_PER_S2);
+    cr_assert_float_eq(ros_vibration_get_band_lower_hz(v), 10.0f, 1e-5);
+    cr_assert_float_eq(ros_vibration_get_band_upper_hz(v), 1000.0f, 1e-5);
+    double x = 0, y = 0, z = 0;
+    ros_vibration_get_vibration(v, &x, &y, &z);
+    cr_assert_float_eq(x, 0.42, 1e-12);
+    cr_assert_float_eq(y, 0.51, 1e-12);
+    cr_assert_float_eq(z, 0.37, 1e-12);
+    cr_assert_eq(ros_vibration_get_clipping_len(v), 3);
+    uint32_t cl[4] = {0};
+    uint32_t n = ros_vibration_get_clipping(v, cl, 4);
+    cr_assert_eq(n, 3);
+    cr_assert_eq(cl[0], 3);
+    cr_assert_eq(cl[1], 1);
+    cr_assert_eq(cl[2], 0);
+    ros_vibration_free(v);
+    free(b);
+}
+
+Test(edgefirst_msgs, vibration_from_cdr_null) {
+    errno = 0;
+    cr_assert_null(ros_vibration_from_cdr(NULL, 100));
+    cr_assert_eq(errno, EINVAL);
+}
+
+Test(edgefirst_msgs, vibration_from_cdr_invalid) {
+    uint8_t bad[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    errno = 0;
+    cr_assert_null(ros_vibration_from_cdr(bad, sizeof(bad)));
+    cr_assert_eq(errno, EBADMSG);
+}
+
+Test(edgefirst_msgs, vibration_free_null) {
+    ros_vibration_free(NULL);
+}
+
+Test(edgefirst_msgs, vibration_getters_null) {
+    cr_assert_eq(ros_vibration_get_stamp_sec(NULL), 0);
+    cr_assert_eq(ros_vibration_get_unit(NULL), 0);
+    cr_assert_eq(ros_vibration_get_clipping_len(NULL), 0);
+    cr_assert_eq(ros_vibration_get_clipping(NULL, NULL, 0), 0);
+    cr_assert_null(ros_vibration_get_frame_id(NULL));
+    ros_vibration_get_vibration(NULL, NULL, NULL, NULL);
+}

--- a/tests/c/test_geometry_msgs.c
+++ b/tests/c/test_geometry_msgs.c
@@ -312,3 +312,81 @@ Test(geometry_msgs, transform_stamped_getters_null) {
     cr_assert_null(ros_transform_stamped_get_frame_id(NULL));
     cr_assert_null(ros_transform_stamped_get_child_frame_id(NULL));
 }
+
+// ============================================================================
+// PoseWithCovariance Tests (CdrFixed — TOP2-770)
+// ============================================================================
+
+Test(geometry_msgs, pose_with_covariance_encode_decode_roundtrip) {
+    uint8_t buf[512];
+    size_t written = 0;
+    double cov_in[36] = {0};
+    for (int i = 0; i < 6; ++i) cov_in[i * 6 + i] = 0.1 * (i + 1);
+    cov_in[1] = 0.01;
+    cov_in[6] = 0.01;
+
+    int ret = ros_pose_with_covariance_encode(
+        buf, sizeof(buf), &written,
+        1.5, -2.5, 3.0,
+        0.0, 0.0, 0.0, 1.0,
+        cov_in);
+    cr_assert_eq(ret, 0);
+    cr_assert_gt(written, 0);
+
+    double px = 0, py = 0, pz = 0, ox = 0, oy = 0, oz = 0, ow = 0;
+    double cov_out[36] = {0};
+    ret = ros_pose_with_covariance_decode(buf, written,
+                                          &px, &py, &pz,
+                                          &ox, &oy, &oz, &ow,
+                                          cov_out);
+    cr_assert_eq(ret, 0);
+    cr_assert_float_eq(px, 1.5, 1e-12);
+    cr_assert_float_eq(py, -2.5, 1e-12);
+    cr_assert_float_eq(pz, 3.0, 1e-12);
+    cr_assert_float_eq(ow, 1.0, 1e-12);
+    cr_assert_float_eq(cov_out[0], 0.1, 1e-12);
+    cr_assert_float_eq(cov_out[35], 0.6, 1e-12);
+    cr_assert_float_eq(cov_out[1], 0.01, 1e-12);
+}
+
+Test(geometry_msgs, pose_with_covariance_encode_null_covariance) {
+    uint8_t buf[512];
+    size_t written = 0;
+    errno = 0;
+    int ret = ros_pose_with_covariance_encode(buf, sizeof(buf), &written,
+                                              0, 0, 0, 0, 0, 0, 1,
+                                              NULL);
+    cr_assert_eq(ret, -1);
+    cr_assert_eq(errno, EINVAL);
+}
+
+// ============================================================================
+// TwistWithCovariance Tests (CdrFixed — TOP2-770)
+// ============================================================================
+
+Test(geometry_msgs, twist_with_covariance_encode_decode_roundtrip) {
+    uint8_t buf[512];
+    size_t written = 0;
+    double cov_in[36] = {0};
+    for (int i = 0; i < 6; ++i) cov_in[i * 6 + i] = 0.02 * (i + 1);
+    cov_in[7] = 0.001;
+
+    int ret = ros_twist_with_covariance_encode(
+        buf, sizeof(buf), &written,
+        1.0, 2.0, 3.0,
+        0.1, 0.2, 0.3,
+        cov_in);
+    cr_assert_eq(ret, 0);
+
+    double lx = 0, ly = 0, lz = 0, ax = 0, ay = 0, az = 0;
+    double cov_out[36] = {0};
+    ret = ros_twist_with_covariance_decode(buf, written,
+                                           &lx, &ly, &lz,
+                                           &ax, &ay, &az,
+                                           cov_out);
+    cr_assert_eq(ret, 0);
+    cr_assert_float_eq(lx, 1.0, 1e-12);
+    cr_assert_float_eq(az, 0.3, 1e-12);
+    cr_assert_float_eq(cov_out[0], 0.02, 1e-12);
+    cr_assert_float_eq(cov_out[7], 0.001, 1e-12);
+}

--- a/tests/c/test_nav_msgs.c
+++ b/tests/c/test_nav_msgs.c
@@ -1,0 +1,93 @@
+/**
+ * @file test_nav_msgs.c
+ * @brief Criterion tests for nav_msgs types (TOP2-770)
+ *
+ * Buffer-backed: Odometry
+ */
+
+#include <criterion/criterion.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "edgefirst/schemas.h"
+
+static uint8_t *load_fixture_nm(const char *relpath, size_t *out_len) {
+    FILE *f = fopen(relpath, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (sz <= 0) { fclose(f); return NULL; }
+    uint8_t *buf = (uint8_t *) malloc((size_t) sz);
+    size_t got = fread(buf, 1, (size_t) sz, f);
+    fclose(f);
+    if (got != (size_t) sz) { free(buf); return NULL; }
+    *out_len = got;
+    return buf;
+}
+
+Test(nav_msgs, odometry_from_golden_fixture) {
+    size_t len = 0;
+    uint8_t *b = load_fixture_nm("testdata/cdr/nav_msgs/Odometry.cdr", &len);
+    cr_assert_not_null(b, "failed to load Odometry fixture");
+    ros_odometry_t *v = ros_odometry_from_cdr(b, len);
+    cr_assert_not_null(v);
+
+    cr_assert_str_eq(ros_odometry_get_frame_id(v), "test_frame");
+    cr_assert_str_eq(ros_odometry_get_child_frame_id(v), "base_link");
+
+    double px = 0, py = 0, pz = 0, ox = 0, oy = 0, oz = 0, ow = 0;
+    ros_odometry_get_pose(v, &px, &py, &pz, &ox, &oy, &oz, &ow);
+    cr_assert_float_eq(px, 1.5, 1e-12);
+    cr_assert_float_eq(pz, 3.0, 1e-12);
+    cr_assert_float_eq(ow, 1.0, 1e-12);
+
+    double pose_cov[36] = {0};
+    ros_odometry_get_pose_covariance(v, pose_cov);
+    cr_assert_float_eq(pose_cov[0], 0.1, 1e-12);
+    cr_assert_float_eq(pose_cov[1], 0.01, 1e-12);
+
+    double lx = 0, ly = 0, lz = 0, ax = 0, ay = 0, az = 0;
+    ros_odometry_get_twist(v, &lx, &ly, &lz, &ax, &ay, &az);
+    cr_assert_float_eq(lx, 1.0, 1e-12);
+    cr_assert_float_eq(az, 0.3, 1e-12);
+
+    double twist_cov[36] = {0};
+    ros_odometry_get_twist_covariance(v, twist_cov);
+    cr_assert_float_eq(twist_cov[0], 0.02, 1e-12);
+    cr_assert_float_eq(twist_cov[7], 0.001, 1e-12);
+
+    ros_odometry_free(v);
+    free(b);
+}
+
+Test(nav_msgs, odometry_from_cdr_null) {
+    errno = 0;
+    cr_assert_null(ros_odometry_from_cdr(NULL, 100));
+    cr_assert_eq(errno, EINVAL);
+}
+
+Test(nav_msgs, odometry_from_cdr_invalid) {
+    uint8_t bad[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    errno = 0;
+    cr_assert_null(ros_odometry_from_cdr(bad, sizeof(bad)));
+    cr_assert_eq(errno, EBADMSG);
+}
+
+Test(nav_msgs, odometry_free_null) {
+    ros_odometry_free(NULL);
+}
+
+Test(nav_msgs, odometry_getters_null) {
+    cr_assert_eq(ros_odometry_get_stamp_sec(NULL), 0);
+    cr_assert_eq(ros_odometry_get_stamp_nanosec(NULL), 0);
+    cr_assert_null(ros_odometry_get_frame_id(NULL));
+    cr_assert_null(ros_odometry_get_child_frame_id(NULL));
+    /* Pointer-out getters must be safe on NULL view. */
+    ros_odometry_get_pose(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    ros_odometry_get_pose_covariance(NULL, NULL);
+    ros_odometry_get_twist(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    ros_odometry_get_twist_covariance(NULL, NULL);
+}

--- a/tests/c/test_sensor_msgs.c
+++ b/tests/c/test_sensor_msgs.c
@@ -8,6 +8,8 @@
 
 #include <criterion/criterion.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 #include "edgefirst/schemas.h"
@@ -331,4 +333,110 @@ Test(sensor_msgs, camera_info_getters_null) {
     cr_assert_null(ros_camera_info_get_distortion_model(NULL));
     cr_assert_eq(ros_camera_info_get_binning_x(NULL), 0);
     cr_assert_eq(ros_camera_info_get_binning_y(NULL), 0);
+}
+
+// ============================================================================
+// MagneticField / FluidPressure / Temperature / BatteryState (TOP2-770)
+// ============================================================================
+
+static uint8_t *_load_fixture_sm(const char *relpath, size_t *out_len) {
+    FILE *f = fopen(relpath, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (sz <= 0) { fclose(f); return NULL; }
+    uint8_t *buf = (uint8_t *) malloc((size_t) sz);
+    size_t got = fread(buf, 1, (size_t) sz, f);
+    fclose(f);
+    if (got != (size_t) sz) { free(buf); return NULL; }
+    *out_len = got;
+    return buf;
+}
+
+Test(sensor_msgs, magnetic_field_from_golden_fixture) {
+    size_t len = 0;
+    uint8_t *b = _load_fixture_sm("testdata/cdr/sensor_msgs/MagneticField.cdr", &len);
+    cr_assert_not_null(b, "failed to load MagneticField fixture");
+    ros_magnetic_field_t *v = ros_magnetic_field_from_cdr(b, len);
+    cr_assert_not_null(v);
+    cr_assert_str_eq(ros_magnetic_field_get_frame_id(v), "test_frame");
+    double x = 0, y = 0, z = 0;
+    ros_magnetic_field_get_magnetic_field(v, &x, &y, &z);
+    cr_assert_float_eq(x, 2.5e-5, 1e-12);
+    cr_assert_float_eq(y, -1.2e-5, 1e-12);
+    cr_assert_float_eq(z, 4.1e-5, 1e-12);
+    double cov[9] = {0};
+    ros_magnetic_field_get_magnetic_field_covariance(v, cov);
+    cr_assert_float_eq(cov[0], 1e-10, 1e-20);
+    ros_magnetic_field_free(v);
+    free(b);
+}
+
+Test(sensor_msgs, magnetic_field_from_cdr_null) {
+    errno = 0;
+    cr_assert_null(ros_magnetic_field_from_cdr(NULL, 100));
+    cr_assert_eq(errno, EINVAL);
+}
+
+Test(sensor_msgs, fluid_pressure_from_golden_fixture) {
+    size_t len = 0;
+    uint8_t *b = _load_fixture_sm("testdata/cdr/sensor_msgs/FluidPressure.cdr", &len);
+    cr_assert_not_null(b);
+    ros_fluid_pressure_t *v = ros_fluid_pressure_from_cdr(b, len);
+    cr_assert_not_null(v);
+    cr_assert_str_eq(ros_fluid_pressure_get_frame_id(v), "test_frame");
+    cr_assert_float_eq(ros_fluid_pressure_get_fluid_pressure(v), 101325.0, 1e-9);
+    cr_assert_float_eq(ros_fluid_pressure_get_variance(v), 25.0, 1e-9);
+    ros_fluid_pressure_free(v);
+    free(b);
+}
+
+Test(sensor_msgs, temperature_from_golden_fixture) {
+    size_t len = 0;
+    uint8_t *b = _load_fixture_sm("testdata/cdr/sensor_msgs/Temperature.cdr", &len);
+    cr_assert_not_null(b);
+    ros_temperature_t *v = ros_temperature_from_cdr(b, len);
+    cr_assert_not_null(v);
+    cr_assert_str_eq(ros_temperature_get_frame_id(v), "test_frame");
+    cr_assert_float_eq(ros_temperature_get_temperature(v), 22.5, 1e-12);
+    cr_assert_float_eq(ros_temperature_get_variance(v), 0.01, 1e-12);
+    ros_temperature_free(v);
+    free(b);
+}
+
+Test(sensor_msgs, battery_state_from_golden_fixture) {
+    size_t len = 0;
+    uint8_t *b = _load_fixture_sm("testdata/cdr/sensor_msgs/BatteryState.cdr", &len);
+    cr_assert_not_null(b);
+    ros_battery_state_t *v = ros_battery_state_from_cdr(b, len);
+    cr_assert_not_null(v);
+    cr_assert_str_eq(ros_battery_state_get_frame_id(v), "test_frame");
+    cr_assert_float_eq(ros_battery_state_get_voltage(v), 12.34f, 1e-5);
+    cr_assert_float_eq(ros_battery_state_get_percentage(v), 0.84f, 1e-5);
+    cr_assert_eq(ros_battery_state_get_power_supply_status(v),
+                 ROS_BATTERY_STATE_POWER_SUPPLY_STATUS_DISCHARGING);
+    cr_assert_eq(ros_battery_state_get_power_supply_technology(v),
+                 ROS_BATTERY_STATE_POWER_SUPPLY_TECHNOLOGY_LIPO);
+    cr_assert(ros_battery_state_get_present(v));
+
+    cr_assert_eq(ros_battery_state_get_cell_voltage_len(v), 3);
+    float cells[4] = {0};
+    uint32_t n = ros_battery_state_get_cell_voltage(v, cells, 4);
+    cr_assert_eq(n, 3);
+    cr_assert_float_eq(cells[0], 4.11f, 1e-5);
+    cr_assert_float_eq(cells[2], 4.10f, 1e-5);
+
+    cr_assert_str_eq(ros_battery_state_get_location(v), "battery0");
+    cr_assert_str_eq(ros_battery_state_get_serial_number(v), "SN0123456");
+
+    ros_battery_state_free(v);
+    free(b);
+}
+
+Test(sensor_msgs, new_types_free_null_ok) {
+    ros_magnetic_field_free(NULL);
+    ros_fluid_pressure_free(NULL);
+    ros_temperature_free(NULL);
+    ros_battery_state_free(NULL);
 }

--- a/tests/cdr_golden.rs
+++ b/tests/cdr_golden.rs
@@ -27,8 +27,10 @@ use edgefirst_schemas::foxglove_msgs::{
     FoxgloveTextAnnotationView,
 };
 use edgefirst_schemas::geometry_msgs::{
-    self, Accel, Inertia, Point, Point32, Pose, Pose2D, Quaternion, Transform, Twist, Vector3,
+    self, Accel, Inertia, Point, Point32, Pose, Pose2D, PoseWithCovariance, Quaternion, Transform,
+    Twist, TwistWithCovariance, Vector3,
 };
+use edgefirst_schemas::nav_msgs;
 use edgefirst_schemas::rosgraph_msgs::Clock;
 use edgefirst_schemas::sensor_msgs::{self, NavSatStatus, PointFieldView, RegionOfInterest};
 use edgefirst_schemas::std_msgs::{self, ColorRGBA};
@@ -2077,4 +2079,436 @@ fn golden_rosgraph_msgs_clock() {
     let re: Clock = decode_fixed(&encode_fixed(&m).unwrap()).unwrap();
     assert_eq!(re.clock.sec, 0);
     assert_eq!(re.clock.nanosec, c.clock.nanosec);
+}
+
+// ── geometry_msgs/PoseWithCovariance, TwistWithCovariance ─────────────────
+
+fn pose_cov_expected() -> [f64; 36] {
+    let mut cov = [0.0_f64; 36];
+    for i in 0..6 {
+        cov[i * 6 + i] = 0.1 * (i as f64 + 1.0);
+    }
+    cov[1] = 0.01;
+    cov[6] = 0.01;
+    cov
+}
+
+fn twist_cov_expected() -> [f64; 36] {
+    let mut cov = [0.0_f64; 36];
+    for i in 0..6 {
+        cov[i * 6 + i] = 0.02 * (i as f64 + 1.0);
+    }
+    cov[7] = 0.001;
+    cov
+}
+
+#[test]
+fn golden_geometry_msgs_pose_with_covariance() {
+    let golden = read_golden("geometry_msgs", "PoseWithCovariance");
+    let p: PoseWithCovariance = decode_fixed(&golden).unwrap();
+    assert_eq!(p.pose.position.x, 1.5);
+    assert_eq!(p.pose.orientation.w, 1.0);
+    assert_eq!(p.covariance, pose_cov_expected());
+    let built = PoseWithCovariance {
+        pose: Pose {
+            position: Point {
+                x: 1.5,
+                y: -2.5,
+                z: 3.0,
+            },
+            orientation: Quaternion {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+                w: 1.0,
+            },
+        },
+        covariance: pose_cov_expected(),
+    };
+    assert_eq!(encode_fixed(&built).unwrap(), golden);
+}
+
+#[test]
+fn golden_geometry_msgs_twist_with_covariance() {
+    let golden = read_golden("geometry_msgs", "TwistWithCovariance");
+    let t: TwistWithCovariance = decode_fixed(&golden).unwrap();
+    assert_eq!(t.twist.linear.x, 1.0);
+    assert_eq!(t.twist.angular.z, 0.3);
+    assert_eq!(t.covariance, twist_cov_expected());
+    let built = TwistWithCovariance {
+        twist: Twist {
+            linear: Vector3 {
+                x: 1.0,
+                y: 2.0,
+                z: 3.0,
+            },
+            angular: Vector3 {
+                x: 0.1,
+                y: 0.2,
+                z: 0.3,
+            },
+        },
+        covariance: twist_cov_expected(),
+    };
+    assert_eq!(encode_fixed(&built).unwrap(), golden);
+}
+
+// ── sensor_msgs/MagneticField, FluidPressure, Temperature, BatteryState ──
+
+#[test]
+fn golden_sensor_msgs_magnetic_field() {
+    let golden = read_golden("sensor_msgs", "MagneticField");
+    let view = sensor_msgs::MagneticField::from_cdr(&golden[..]).unwrap();
+    assert_eq!(view.stamp(), STAMP);
+    assert_eq!(view.frame_id(), FRAME_ID);
+    let mf = view.magnetic_field();
+    assert_eq!(mf.x, 2.5e-5);
+    assert_eq!(mf.y, -1.2e-5);
+    assert_eq!(mf.z, 4.1e-5);
+    let cov = view.magnetic_field_covariance();
+    assert_eq!(cov[0], 1e-10);
+    assert_eq!(cov[4], 1e-10);
+    assert_eq!(cov[8], 1e-10);
+    let built = sensor_msgs::MagneticField::new(
+        STAMP,
+        FRAME_ID,
+        Vector3 {
+            x: 2.5e-5,
+            y: -1.2e-5,
+            z: 4.1e-5,
+        },
+        [1e-10, 0.0, 0.0, 0.0, 1e-10, 0.0, 0.0, 0.0, 1e-10],
+    )
+    .unwrap();
+    assert_eq!(built.to_cdr(), golden);
+}
+
+#[test]
+fn golden_sensor_msgs_fluid_pressure() {
+    let golden = read_golden("sensor_msgs", "FluidPressure");
+    let view = sensor_msgs::FluidPressure::from_cdr(&golden[..]).unwrap();
+    assert_eq!(view.stamp(), STAMP);
+    assert_eq!(view.frame_id(), FRAME_ID);
+    assert_eq!(view.fluid_pressure(), 101325.0);
+    assert_eq!(view.variance(), 25.0);
+    let built = sensor_msgs::FluidPressure::new(STAMP, FRAME_ID, 101325.0, 25.0).unwrap();
+    assert_eq!(built.to_cdr(), golden);
+}
+
+#[test]
+fn golden_sensor_msgs_temperature() {
+    let golden = read_golden("sensor_msgs", "Temperature");
+    let view = sensor_msgs::Temperature::from_cdr(&golden[..]).unwrap();
+    assert_eq!(view.stamp(), STAMP);
+    assert_eq!(view.frame_id(), FRAME_ID);
+    assert_eq!(view.temperature(), 22.5);
+    assert_eq!(view.variance(), 0.01);
+    let built = sensor_msgs::Temperature::new(STAMP, FRAME_ID, 22.5, 0.01).unwrap();
+    assert_eq!(built.to_cdr(), golden);
+}
+
+#[test]
+fn golden_sensor_msgs_battery_state() {
+    let golden = read_golden("sensor_msgs", "BatteryState");
+    let view = sensor_msgs::BatteryState::from_cdr(&golden[..]).unwrap();
+    assert_eq!(view.stamp(), STAMP);
+    assert_eq!(view.frame_id(), FRAME_ID);
+    assert_eq!(view.voltage(), 12.34);
+    assert_eq!(view.temperature(), 27.5);
+    assert_eq!(view.current(), -2.1);
+    assert_eq!(view.charge(), 4.2);
+    assert_eq!(view.capacity(), 5.0);
+    assert_eq!(view.design_capacity(), 5.0);
+    assert_eq!(view.percentage(), 0.84);
+    assert_eq!(view.power_supply_status(), 2);
+    assert_eq!(view.power_supply_health(), 1);
+    assert_eq!(view.power_supply_technology(), 3);
+    assert!(view.present());
+    assert_eq!(view.cell_voltage(), vec![4.11, 4.12, 4.10]);
+    assert_eq!(view.cell_temperature(), vec![27.1, 27.3, 27.4]);
+    assert_eq!(view.location(), "battery0");
+    assert_eq!(view.serial_number(), "SN0123456");
+    let built = sensor_msgs::BatteryState::new(
+        STAMP,
+        FRAME_ID,
+        12.34,
+        27.5,
+        -2.1,
+        4.2,
+        5.0,
+        5.0,
+        0.84,
+        2,
+        1,
+        3,
+        true,
+        &[4.11, 4.12, 4.10],
+        &[27.1, 27.3, 27.4],
+        "battery0",
+        "SN0123456",
+    )
+    .unwrap();
+    assert_eq!(built.to_cdr(), golden);
+}
+
+// ── nav_msgs/Odometry ───────────────────────────────────────────────────
+
+#[test]
+fn golden_nav_msgs_odometry() {
+    let golden = read_golden("nav_msgs", "Odometry");
+    let view = nav_msgs::Odometry::from_cdr(&golden[..]).unwrap();
+    assert_eq!(view.stamp(), STAMP);
+    assert_eq!(view.frame_id(), FRAME_ID);
+    assert_eq!(view.child_frame_id(), "base_link");
+    let p = view.pose();
+    assert_eq!(p.pose.position.x, 1.5);
+    assert_eq!(p.covariance, pose_cov_expected());
+    let t = view.twist();
+    assert_eq!(t.twist.linear.x, 1.0);
+    assert_eq!(t.covariance, twist_cov_expected());
+    let built = nav_msgs::Odometry::new(
+        STAMP,
+        FRAME_ID,
+        "base_link",
+        PoseWithCovariance {
+            pose: Pose {
+                position: Point {
+                    x: 1.5,
+                    y: -2.5,
+                    z: 3.0,
+                },
+                orientation: Quaternion {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                    w: 1.0,
+                },
+            },
+            covariance: pose_cov_expected(),
+        },
+        TwistWithCovariance {
+            twist: Twist {
+                linear: Vector3 {
+                    x: 1.0,
+                    y: 2.0,
+                    z: 3.0,
+                },
+                angular: Vector3 {
+                    x: 0.1,
+                    y: 0.2,
+                    z: 0.3,
+                },
+            },
+            covariance: twist_cov_expected(),
+        },
+    )
+    .unwrap();
+    assert_eq!(built.to_cdr(), golden);
+}
+
+// ── edgefirst_msgs/Vibration ────────────────────────────────────────────
+
+#[test]
+fn golden_edgefirst_msgs_vibration() {
+    let golden = read_golden("edgefirst_msgs", "Vibration");
+    let view = edgefirst_msgs::Vibration::from_cdr(&golden[..]).unwrap();
+    assert_eq!(view.stamp(), STAMP);
+    assert_eq!(view.frame_id(), FRAME_ID);
+    assert_eq!(view.measurement_type(), 1);
+    assert_eq!(view.unit(), 1);
+    assert_eq!(view.band_lower_hz(), 10.0);
+    assert_eq!(view.band_upper_hz(), 1000.0);
+    let v = view.vibration();
+    assert_eq!(v.x, 0.42);
+    assert_eq!(v.y, 0.51);
+    assert_eq!(v.z, 0.37);
+    assert_eq!(view.clipping(), vec![3, 1, 0]);
+    let built = edgefirst_msgs::Vibration::new(
+        STAMP,
+        FRAME_ID,
+        1,
+        1,
+        10.0,
+        1000.0,
+        Vector3 {
+            x: 0.42,
+            y: 0.51,
+            z: 0.37,
+        },
+        &[3, 1, 0],
+    )
+    .unwrap();
+    assert_eq!(built.to_cdr(), golden);
+}
+
+// ── EDGEAI-1243 alignment regression prevention ────────────────────────
+// Every Header-prefixed buffer-backed type MUST read back the values it
+// encoded for every `frame_id` length. Sweeping 0..=16 covers every
+// CDR-relative mod-8 residue of the first post-Header offset.
+
+#[test]
+fn frame_id_alignment_sweep_magnetic_field() {
+    let mf = Vector3 {
+        x: 1.0,
+        y: 2.0,
+        z: 3.0,
+    };
+    let cov = [0.1_f64, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+    for len in 0..=16_usize {
+        let fid: String = "x".repeat(len);
+        let built = sensor_msgs::MagneticField::new(STAMP, &fid, mf, cov).unwrap();
+        let bytes = built.to_cdr();
+        let view = sensor_msgs::MagneticField::from_cdr(&bytes[..]).unwrap();
+        assert_eq!(view.frame_id(), fid, "frame_id at len={len}");
+        assert_eq!(view.magnetic_field(), mf, "magnetic_field at len={len}");
+        assert_eq!(
+            view.magnetic_field_covariance(),
+            cov,
+            "covariance at len={len}"
+        );
+    }
+}
+
+#[test]
+fn frame_id_alignment_sweep_fluid_pressure() {
+    for len in 0..=16_usize {
+        let fid: String = "x".repeat(len);
+        let built = sensor_msgs::FluidPressure::new(STAMP, &fid, 101_234.5, 0.5).unwrap();
+        let bytes = built.to_cdr();
+        let view = sensor_msgs::FluidPressure::from_cdr(&bytes[..]).unwrap();
+        assert_eq!(view.frame_id(), fid, "frame_id at len={len}");
+        assert_eq!(view.fluid_pressure(), 101_234.5, "pressure at len={len}");
+        assert_eq!(view.variance(), 0.5, "variance at len={len}");
+    }
+}
+
+#[test]
+fn frame_id_alignment_sweep_temperature() {
+    for len in 0..=16_usize {
+        let fid: String = "x".repeat(len);
+        let built = sensor_msgs::Temperature::new(STAMP, &fid, 21.25, 0.03).unwrap();
+        let bytes = built.to_cdr();
+        let view = sensor_msgs::Temperature::from_cdr(&bytes[..]).unwrap();
+        assert_eq!(view.frame_id(), fid, "frame_id at len={len}");
+        assert_eq!(view.temperature(), 21.25, "temperature at len={len}");
+        assert_eq!(view.variance(), 0.03, "variance at len={len}");
+    }
+}
+
+#[test]
+fn frame_id_alignment_sweep_battery_state() {
+    for len in 0..=16_usize {
+        let fid: String = "x".repeat(len);
+        let built = sensor_msgs::BatteryState::new(
+            STAMP,
+            &fid,
+            12.0,
+            25.5,
+            -1.5,
+            3.2,
+            4.0,
+            4.0,
+            0.8,
+            2,
+            1,
+            3,
+            true,
+            &[4.01, 4.02, 4.03],
+            &[25.1, 25.2, 25.3],
+            "slot0",
+            "SN0001",
+        )
+        .unwrap();
+        let bytes = built.to_cdr();
+        let view = sensor_msgs::BatteryState::from_cdr(&bytes[..]).unwrap();
+        assert_eq!(view.frame_id(), fid, "frame_id at len={len}");
+        assert_eq!(view.voltage(), 12.0, "voltage at len={len}");
+        assert_eq!(view.percentage(), 0.8, "percentage at len={len}");
+        assert_eq!(
+            view.cell_voltage(),
+            vec![4.01, 4.02, 4.03],
+            "cell_voltage at len={len}"
+        );
+        assert_eq!(view.location(), "slot0", "location at len={len}");
+        assert_eq!(view.serial_number(), "SN0001", "serial at len={len}");
+    }
+}
+
+#[test]
+fn frame_id_alignment_sweep_odometry() {
+    let pose = PoseWithCovariance {
+        pose: Pose {
+            position: Point {
+                x: 1.0,
+                y: 2.0,
+                z: 3.0,
+            },
+            orientation: Quaternion {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+                w: 1.0,
+            },
+        },
+        covariance: pose_cov_expected(),
+    };
+    let twist = TwistWithCovariance {
+        twist: Twist {
+            linear: Vector3 {
+                x: 0.5,
+                y: 0.25,
+                z: 0.125,
+            },
+            angular: Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.1,
+            },
+        },
+        covariance: twist_cov_expected(),
+    };
+    for len in 0..=16_usize {
+        let fid: String = "f".repeat(len);
+        let built = nav_msgs::Odometry::new(STAMP, &fid, "child", pose, twist).unwrap();
+        let bytes = built.to_cdr();
+        let view = nav_msgs::Odometry::from_cdr(&bytes[..]).unwrap();
+        assert_eq!(view.frame_id(), fid, "frame_id at len={len}");
+        assert_eq!(view.child_frame_id(), "child", "child at len={len}");
+        assert_eq!(view.pose().pose.position.x, 1.0, "pose.x at len={len}");
+        assert_eq!(
+            view.pose().covariance,
+            pose_cov_expected(),
+            "pose.cov at len={len}"
+        );
+        assert_eq!(view.twist().twist.linear.x, 0.5, "twist.x at len={len}");
+        assert_eq!(
+            view.twist().covariance,
+            twist_cov_expected(),
+            "twist.cov at len={len}"
+        );
+    }
+}
+
+#[test]
+fn frame_id_alignment_sweep_vibration() {
+    let vib = Vector3 {
+        x: 0.1,
+        y: 0.2,
+        z: 0.3,
+    };
+    for len in 0..=16_usize {
+        let fid: String = "v".repeat(len);
+        let built =
+            edgefirst_msgs::Vibration::new(STAMP, &fid, 1, 1, 10.0, 1000.0, vib, &[1, 2, 3])
+                .unwrap();
+        let bytes = built.to_cdr();
+        let view = edgefirst_msgs::Vibration::from_cdr(&bytes[..]).unwrap();
+        assert_eq!(view.frame_id(), fid, "frame_id at len={len}");
+        assert_eq!(view.measurement_type(), 1, "measurement_type at len={len}");
+        assert_eq!(view.unit(), 1, "unit at len={len}");
+        assert_eq!(view.band_lower_hz(), 10.0, "band_lower at len={len}");
+        assert_eq!(view.band_upper_hz(), 1000.0, "band_upper at len={len}");
+        assert_eq!(view.vibration(), vib, "vibration at len={len}");
+        assert_eq!(view.clipping(), vec![1, 2, 3], "clipping at len={len}");
+    }
 }

--- a/tests/cpp/test_top2_770_schemas.cpp
+++ b/tests/cpp/test_top2_770_schemas.cpp
@@ -1,0 +1,190 @@
+/**
+ * @file test_top2_770_schemas.cpp
+ * @brief C++ tests for TOP2-770 schema additions:
+ *        PoseWithCovariance, TwistWithCovariance, MagneticField,
+ *        FluidPressure, Temperature, BatteryState, Odometry, Vibration.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Au-Zone Technologies. All Rights Reserved.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+#include <edgefirst/schemas.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace ef = edgefirst::schemas;
+
+static std::vector<std::uint8_t> load_fixture(const std::string& relpath) {
+    std::FILE* f = std::fopen(relpath.c_str(), "rb");
+    REQUIRE(f != nullptr);
+    std::fseek(f, 0, SEEK_END);
+    long sz = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    std::vector<std::uint8_t> buf(static_cast<std::size_t>(sz));
+    std::size_t got = std::fread(buf.data(), 1, buf.size(), f);
+    std::fclose(f);
+    REQUIRE(got == buf.size());
+    return buf;
+}
+
+// ── CdrFixed ───────────────────────────────────────────────────────────
+
+TEST_CASE("PoseWithCovariance encode/decode roundtrip", "[top2_770]") {
+    ef::PoseWithCovariance p(ef::Pose{1.5, -2.5, 3.0, 0.0, 0.0, 0.0, 1.0}, {});
+    for (int i = 0; i < 6; ++i) {
+        p.covariance[i * 6 + i] = 0.1 * (i + 1);
+    }
+    p.covariance[1] = 0.01;
+    p.covariance[6] = 0.01;
+    auto sz = p.encoded_size();
+    REQUIRE(sz.has_value());
+    std::vector<std::uint8_t> buf(*sz);
+    auto w = p.encode(ef::span<std::uint8_t>{buf.data(), buf.size()});
+    REQUIRE(w.has_value());
+    auto dec = ef::PoseWithCovariance::decode(
+        ef::span<const std::uint8_t>{buf.data(), *w});
+    REQUIRE(dec.has_value());
+    CHECK(dec->pose.px == 1.5);
+    CHECK(dec->pose.ow == 1.0);
+    CHECK(dec->covariance[0] == 0.1);
+    CHECK(dec->covariance[35] == Approx(0.6));
+    CHECK(dec->covariance[1] == 0.01);
+}
+
+TEST_CASE("TwistWithCovariance encode/decode roundtrip", "[top2_770]") {
+    ef::TwistWithCovariance t(ef::Twist{1.0, 2.0, 3.0, 0.1, 0.2, 0.3}, {});
+    for (int i = 0; i < 6; ++i) {
+        t.covariance[i * 6 + i] = 0.02 * (i + 1);
+    }
+    t.covariance[7] = 0.001;
+    auto sz = t.encoded_size();
+    REQUIRE(sz.has_value());
+    std::vector<std::uint8_t> buf(*sz);
+    auto w = t.encode(ef::span<std::uint8_t>{buf.data(), buf.size()});
+    REQUIRE(w.has_value());
+    auto dec = ef::TwistWithCovariance::decode(
+        ef::span<const std::uint8_t>{buf.data(), *w});
+    REQUIRE(dec.has_value());
+    CHECK(dec->twist.lx == 1.0);
+    CHECK(dec->twist.az == 0.3);
+    CHECK(dec->covariance[0] == 0.02);
+    CHECK(dec->covariance[7] == 0.001);
+}
+
+// ── Buffer-backed (view-only) ─────────────────────────────────────────
+
+TEST_CASE("MagneticFieldView decodes golden fixture", "[top2_770]") {
+    auto bytes = load_fixture("testdata/cdr/sensor_msgs/MagneticField.cdr");
+    auto view = ef::MagneticFieldView::from_cdr(
+        ef::span<const std::uint8_t>{bytes.data(), bytes.size()});
+    REQUIRE(view.has_value());
+    CHECK(view->frame_id() == "test_frame");
+    auto mf = view->magnetic_field();
+    CHECK(mf.x == Approx(2.5e-5));
+    CHECK(mf.y == Approx(-1.2e-5));
+    CHECK(mf.z == Approx(4.1e-5));
+    auto cov = view->magnetic_field_covariance();
+    CHECK(cov[0] == Approx(1e-10));
+    CHECK(cov[4] == Approx(1e-10));
+}
+
+TEST_CASE("FluidPressureView decodes golden fixture", "[top2_770]") {
+    auto bytes = load_fixture("testdata/cdr/sensor_msgs/FluidPressure.cdr");
+    auto view = ef::FluidPressureView::from_cdr(
+        ef::span<const std::uint8_t>{bytes.data(), bytes.size()});
+    REQUIRE(view.has_value());
+    CHECK(view->frame_id() == "test_frame");
+    CHECK(view->fluid_pressure() == Approx(101325.0));
+    CHECK(view->variance() == Approx(25.0));
+}
+
+TEST_CASE("TemperatureView decodes golden fixture", "[top2_770]") {
+    auto bytes = load_fixture("testdata/cdr/sensor_msgs/Temperature.cdr");
+    auto view = ef::TemperatureView::from_cdr(
+        ef::span<const std::uint8_t>{bytes.data(), bytes.size()});
+    REQUIRE(view.has_value());
+    CHECK(view->frame_id() == "test_frame");
+    CHECK(view->temperature() == Approx(22.5));
+    CHECK(view->variance() == Approx(0.01));
+}
+
+TEST_CASE("BatteryStateView decodes golden fixture", "[top2_770]") {
+    auto bytes = load_fixture("testdata/cdr/sensor_msgs/BatteryState.cdr");
+    auto view = ef::BatteryStateView::from_cdr(
+        ef::span<const std::uint8_t>{bytes.data(), bytes.size()});
+    REQUIRE(view.has_value());
+    CHECK(view->frame_id() == "test_frame");
+    CHECK(view->voltage() == Approx(12.34f));
+    CHECK(view->percentage() == Approx(0.84f));
+    CHECK(view->power_supply_status()
+          == ef::BatteryStateView::POWER_SUPPLY_STATUS_DISCHARGING);
+    CHECK(view->power_supply_technology()
+          == ef::BatteryStateView::POWER_SUPPLY_TECHNOLOGY_LIPO);
+    CHECK(view->present());
+    CHECK(view->cell_voltage_len() == 3u);
+    std::array<float, 4> cells{};
+    auto n = view->cell_voltage(
+        ef::span<float>{cells.data(), cells.size()});
+    CHECK(n == 3u);
+    CHECK(cells[0] == Approx(4.11f));
+    CHECK(cells[2] == Approx(4.10f));
+    CHECK(view->location() == "battery0");
+    CHECK(view->serial_number() == "SN0123456");
+}
+
+TEST_CASE("OdometryView decodes golden fixture", "[top2_770]") {
+    auto bytes = load_fixture("testdata/cdr/nav_msgs/Odometry.cdr");
+    auto view = ef::OdometryView::from_cdr(
+        ef::span<const std::uint8_t>{bytes.data(), bytes.size()});
+    REQUIRE(view.has_value());
+    CHECK(view->frame_id() == "test_frame");
+    CHECK(view->child_frame_id() == "base_link");
+    auto p = view->pose();
+    CHECK(p.pose.px == Approx(1.5));
+    CHECK(p.pose.ow == Approx(1.0));
+    CHECK(p.covariance[0] == Approx(0.1));
+    auto t = view->twist();
+    CHECK(t.twist.lx == Approx(1.0));
+    CHECK(t.twist.az == Approx(0.3));
+    CHECK(t.covariance[7] == Approx(0.001));
+}
+
+TEST_CASE("VibrationView decodes golden fixture", "[top2_770]") {
+    auto bytes = load_fixture("testdata/cdr/edgefirst_msgs/Vibration.cdr");
+    auto view = ef::VibrationView::from_cdr(
+        ef::span<const std::uint8_t>{bytes.data(), bytes.size()});
+    REQUIRE(view.has_value());
+    CHECK(view->frame_id() == "test_frame");
+    CHECK(view->measurement_type() == ef::VibrationView::MEASUREMENT_RMS);
+    CHECK(view->unit() == ef::VibrationView::UNIT_ACCEL_M_PER_S2);
+    CHECK(view->band_lower_hz() == Approx(10.0f));
+    CHECK(view->band_upper_hz() == Approx(1000.0f));
+    auto v = view->vibration();
+    CHECK(v.x == Approx(0.42));
+    CHECK(v.y == Approx(0.51));
+    CHECK(v.z == Approx(0.37));
+    CHECK(view->clipping_len() == 3u);
+    std::array<std::uint32_t, 4> cl{};
+    auto n = view->clipping(
+        ef::span<std::uint32_t>{cl.data(), cl.size()});
+    CHECK(n == 3u);
+    CHECK(cl[0] == 3u);
+    CHECK(cl[1] == 1u);
+    CHECK(cl[2] == 0u);
+}
+
+TEST_CASE("new view types are move-only", "[top2_770][lifetime]") {
+    STATIC_REQUIRE_FALSE(std::is_copy_constructible_v<ef::MagneticFieldView>);
+    STATIC_REQUIRE(std::is_move_constructible_v<ef::MagneticFieldView>);
+    STATIC_REQUIRE_FALSE(std::is_copy_constructible_v<ef::OdometryView>);
+    STATIC_REQUIRE(std::is_move_constructible_v<ef::OdometryView>);
+    STATIC_REQUIRE_FALSE(std::is_copy_constructible_v<ef::VibrationView>);
+    STATIC_REQUIRE(std::is_move_constructible_v<ef::VibrationView>);
+}

--- a/tests/cpp/test_top2_770_schemas.cpp
+++ b/tests/cpp/test_top2_770_schemas.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace ef = edgefirst::schemas;
@@ -24,9 +25,10 @@ namespace ef = edgefirst::schemas;
 static std::vector<std::uint8_t> load_fixture(const std::string& relpath) {
     std::FILE* f = std::fopen(relpath.c_str(), "rb");
     REQUIRE(f != nullptr);
-    std::fseek(f, 0, SEEK_END);
+    REQUIRE(std::fseek(f, 0, SEEK_END) == 0);
     long sz = std::ftell(f);
-    std::fseek(f, 0, SEEK_SET);
+    REQUIRE(sz >= 0);
+    REQUIRE(std::fseek(f, 0, SEEK_SET) == 0);
     std::vector<std::uint8_t> buf(static_cast<std::size_t>(sz));
     std::size_t got = std::fread(buf.data(), 1, buf.size(), f);
     std::fclose(f);

--- a/tests/python/test_schema_registry.py
+++ b/tests/python/test_schema_registry.py
@@ -173,18 +173,25 @@ class TestCrossLanguageCompatibility:
 
     # List of schemas that must match between Python and Rust
     COMMON_SCHEMAS = [
+        "sensor_msgs/msg/BatteryState",
         "sensor_msgs/msg/CameraInfo",
         "sensor_msgs/msg/CompressedImage",
+        "sensor_msgs/msg/FluidPressure",
         "sensor_msgs/msg/Image",
         "sensor_msgs/msg/Imu",
+        "sensor_msgs/msg/MagneticField",
         "sensor_msgs/msg/NavSatFix",
         "sensor_msgs/msg/PointCloud2",
+        "sensor_msgs/msg/Temperature",
         "geometry_msgs/msg/Pose",
+        "geometry_msgs/msg/PoseWithCovariance",
         "geometry_msgs/msg/Transform",
         "geometry_msgs/msg/TransformStamped",
         "geometry_msgs/msg/Twist",
+        "geometry_msgs/msg/TwistWithCovariance",
         "geometry_msgs/msg/Vector3",
         "geometry_msgs/msg/Quaternion",
+        "nav_msgs/msg/Odometry",
         "foxglove_msgs/msg/CompressedVideo",
         "edgefirst_msgs/msg/Box",
         "edgefirst_msgs/msg/CameraFrame",
@@ -195,6 +202,7 @@ class TestCrossLanguageCompatibility:
         "edgefirst_msgs/msg/ModelInfo",
         "edgefirst_msgs/msg/RadarCube",
         "edgefirst_msgs/msg/RadarInfo",
+        "edgefirst_msgs/msg/Vibration",
         "edgefirst_msgs/msg/Track",
     ]
 


### PR DESCRIPTION
## Summary

Implements the seven ROS 2 `common_interfaces` schemas required by `adis-uav-mavlink` (TOP2-766) plus one new `edgefirst_msgs` type. Full Rust + Python + C + C++ surface with golden CDR fixtures. Lands alongside CameraFrame (merged) and the EDGEAI-1243 fix under \`[Unreleased]\`.

## New types (8)

| Type | Source | Category |
|---|---|---|
| \`geometry_msgs/PoseWithCovariance\` | ros2/common_interfaces | CdrFixed (344 B) |
| \`geometry_msgs/TwistWithCovariance\` | ros2/common_interfaces | CdrFixed (336 B) |
| \`sensor_msgs/MagneticField\` | ros2/common_interfaces | buffer-backed |
| \`sensor_msgs/FluidPressure\` | ros2/common_interfaces | buffer-backed |
| \`sensor_msgs/Temperature\` | ros2/common_interfaces | buffer-backed |
| \`sensor_msgs/BatteryState\` | ros2/common_interfaces | buffer-backed, 20 constants |
| \`nav_msgs/Odometry\` | ros2/common_interfaces | buffer-backed, new \`nav_msgs\` module |
| \`edgefirst_msgs/Vibration\` | TOP2-770 (new) | buffer-backed, 11 constants |

## EDGEAI-1243 class prevention

Every new Header-prefixed buffer-backed type caches post-variable-string cursor positions into its offset table (no \`CDR_SIZE\` arithmetic across variable padding). Six new parametric \`frame_id\`-length sweep tests (lengths 0..=16) guard against the alignment bug class going forward. While implementing Vibration the rule was violated (constant offset across \`u8,u8,f32\` padding) — golden test caught it, fixed by caching the aligned f32 start.

## Cross-language coverage

- **Rust**: new types in \`src/{geometry_msgs,sensor_msgs,nav_msgs,edgefirst_msgs}.rs\`; \`nav_msgs\` module registered in \`lib.rs\` + \`schema_registry.rs\`.
- **C**: \`ros_<type>_t\` opaque handles + \`from_cdr/free/get_*/as_cdr\` for buffer-backed types; \`encode/decode\` pair for CdrFixed. \`ros_*\` prefix preserved for 3.x (per-namespace normalization deferred to 4.0.0 per EDGEAI-1240 precedent).
- **C++**: header-only move-only \`View\` classes + value classes \`PoseWithCovariance\`/\`TwistWithCovariance\`. \`BatteryStateView\` and \`VibrationView\` expose constants as \`static constexpr\`.
- **Python**: \`edgefirst_msgs.Vibration\` dataclass + \`VibrationMeasurement\` / \`VibrationUnit\` enums. Other dataclasses already present in the Python package.

## Test totals

- \`cargo test --test cdr_golden\`: 72 passed (up from 58) — 8 new golden tests + 6 parametric sweeps
- \`cargo test\` lib/doc/mcap: all green
- \`pytest tests/python/\`: 301 passed
- \`make test-c\`: all green (one new file: \`test_nav_msgs.c\`; extensions in 3 other files)
- \`make test-cpp\`: \`test_top2_770_schemas\` adds 84 assertions / 9 test cases
- \`python3 scripts/generate_cdr_testdata.py --verify\`: all fixtures stable

## Deferred (per TOP2-770 open questions)

Not in this PR; follow-up tickets: \`edgefirst/ServiceStatus\`, flight-mode/armed-state custom type, attitude custom type, barometric-altitude custom type, 4.0.0 C-prefix normalization.

## Test plan

- [x] All Rust / Python / C / C++ tests green locally.
- [x] Fixture generator \`--verify\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Regression-style alignment sweeps exist for every new Header-prefixed type.