### PR TITLE
EDGEAI-1291: Zero-copy from_cdr for Python bytes inputs

### DIFF
--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -14,11 +14,16 @@
 //! (`from edgefirst.schemas.sensor_msgs import Image`) resolve directly
 //! to the in-binary objects.
 //!
-//! Heavy types accept any object implementing the buffer protocol
-//! (`bytes`, `bytearray`, `memoryview`, `numpy.ndarray`, `array.array`)
-//! for their bulk payload via [`PyBuffer<u8>`]. Phase 1 copies the payload
-//! into the CDR buffer once with the GIL released; phase 2 will add a
-//! `borrow=True` opt-in for true zero-copy via composite buffers.
+//! ## Buffer semantics
+//!
+//! **`from_cdr(buf)`** — zero-copy for `bytes`, safe copy otherwise:
+//! - `bytes` → borrowed zero-copy (the message holds a refcount on the
+//!   input; no memcpy).
+//! - `bytearray` / `memoryview` / other mutable buffer → copied under
+//!   the GIL (prevents data races from concurrent Python threads).
+//!
+//! **`Type(…, data=buf)`** (builders) — always copies the bulk payload
+//! into the CDR buffer with the GIL released for the heavy build step.
 
 #[cfg(any(not(Py_LIMITED_API), Py_3_11))]
 use std::ffi::{c_int, c_void, CString};
@@ -195,6 +200,66 @@ fn copy_buffer(buf: &Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
     let owned = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
     drop(pybuf);
     Ok(owned)
+}
+
+// ── PyBuf — zero-copy or owned CDR buffer ───────────────────────────
+
+/// A CDR buffer that is either owned (`Vec<u8>`) or borrowed zero-copy
+/// from a Python `bytes` object.
+///
+/// # Safety invariants
+///
+/// For `Borrowed`:
+/// - `obj` is a `Py<PyBytes>` whose refcount keeps the underlying
+///   CPython bytes object alive (preventing GC).
+/// - `ptr` and `len` are derived from the immutable bytes buffer and
+///   remain valid for the lifetime of `obj`. CPython `bytes` objects
+///   never move or reallocate their internal buffer.
+/// - Concurrent reads are safe because the bytes content is immutable.
+pub enum PyBuf {
+    Owned(Vec<u8>),
+    Borrowed {
+        obj: Py<PyBytes>,
+        ptr: *const u8,
+        len: usize,
+    },
+}
+
+// Safety: Py<PyBytes> is Send+Sync. The raw pointer is derived from an
+// immutable bytes object whose lifetime is held by `obj`. Concurrent
+// reads of immutable data are safe (same reasoning as &[u8]: Sync).
+unsafe impl Send for PyBuf {}
+unsafe impl Sync for PyBuf {}
+
+impl AsRef<[u8]> for PyBuf {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            PyBuf::Owned(v) => v.as_ref(),
+            // Safety: ptr/len are derived from a Py<PyBytes> that is kept
+            // alive by the `obj` field. Bytes content is immutable.
+            PyBuf::Borrowed { ptr, len, .. } => unsafe { std::slice::from_raw_parts(*ptr, *len) },
+        }
+    }
+}
+
+/// Acquire a CDR buffer from a Python object, choosing zero-copy or copy
+/// based on mutability.
+///
+/// - `bytes` input → zero-copy `PyBuf::Borrowed` (no memcpy)
+/// - `bytearray` / `memoryview` / other → copied `PyBuf::Owned` (GIL-safe)
+fn smart_buffer(buf: &Bound<'_, PyAny>) -> PyResult<PyBuf> {
+    // Fast path: if it's a `bytes` object, borrow zero-copy.
+    if let Ok(pybytes) = buf.downcast::<PyBytes>() {
+        let slice = pybytes.as_bytes();
+        let ptr = slice.as_ptr();
+        let len = slice.len();
+        let obj: Py<PyBytes> = pybytes.clone().unbind();
+        return Ok(PyBuf::Borrowed { obj, ptr, len });
+    }
+    // Slow path: copy under GIL for mutable buffer safety.
+    let owned = copy_buffer(buf)?;
+    Ok(PyBuf::Owned(owned))
 }
 
 // ── BorrowedBuf — buffer-protocol view with parent lifetime ─────────
@@ -925,7 +990,7 @@ impl PyTwist {
 /// buffer; metadata fields read directly from the buffer at known offsets.
 #[pyclass(name = "Header", module = "edgefirst.schemas.std_msgs", frozen)]
 pub struct PyHeader {
-    inner: Header<Vec<u8>>,
+    inner: Header<PyBuf>,
 }
 
 #[pymethods]
@@ -939,7 +1004,9 @@ impl PyHeader {
             .frame_id(frame_id)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     /// Decode an existing CDR buffer. Currently copies the buffer into a
@@ -950,8 +1017,8 @@ impl PyHeader {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Header::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Header::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -994,7 +1061,7 @@ impl PyHeader {
 /// `memoryview`, etc.
 #[pyclass(name = "Image", module = "edgefirst.schemas.sensor_msgs", frozen)]
 pub struct PyImage {
-    inner: Image<Vec<u8>>,
+    inner: Image<PyBuf>,
 }
 
 #[pymethods]
@@ -1037,7 +1104,9 @@ impl PyImage {
                 .build()
         });
         let inner = inner.map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     /// Decode an existing CDR buffer. Phase 1 copies; phase 2 will offer a
@@ -1048,8 +1117,8 @@ impl PyImage {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Image::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Image::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -1359,7 +1428,7 @@ impl PyDate {
     frozen
 )]
 pub struct PyCompressedImage {
-    inner: CompressedImage<Vec<u8>>,
+    inner: CompressedImage<PyBuf>,
 }
 
 #[pymethods]
@@ -1386,7 +1455,9 @@ impl PyCompressedImage {
                 .build()
         });
         let inner = inner.map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -1395,8 +1466,8 @@ impl PyCompressedImage {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = CompressedImage::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = CompressedImage::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -1452,7 +1523,7 @@ impl PyCompressedImage {
 /// (e.g. "" or "zstd") and a `boxed` flag.
 #[pyclass(name = "Mask", module = "edgefirst.schemas.edgefirst_msgs", frozen)]
 pub struct PyMask {
-    inner: Mask<Vec<u8>>,
+    inner: Mask<PyBuf>,
 }
 
 #[pymethods]
@@ -1482,7 +1553,9 @@ impl PyMask {
                 .build()
         });
         let inner = inner.map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -1491,8 +1564,8 @@ impl PyMask {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Mask::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Mask::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -1565,7 +1638,7 @@ impl PyMask {
 )]
 #[allow(deprecated)]
 pub struct PyDmaBuffer {
-    inner: DmaBuffer<Vec<u8>>,
+    inner: DmaBuffer<PyBuf>,
 }
 
 #[pymethods]
@@ -1589,7 +1662,9 @@ impl PyDmaBuffer {
             stamp, frame_id, pid, fd, width, height, stride, fourcc, length,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -1598,8 +1673,8 @@ impl PyDmaBuffer {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = DmaBuffer::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = DmaBuffer::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -1665,7 +1740,7 @@ impl PyDmaBuffer {
     frozen
 )]
 pub struct PyRadarCube {
-    inner: RadarCube<Vec<u8>>,
+    inner: RadarCube<PyBuf>,
 }
 
 #[pymethods]
@@ -1747,7 +1822,7 @@ impl PyRadarCube {
                 .is_complex(is_complex)
                 .build()
         });
-        let inner = inner.map_err(map_cdr_err)?;
+        let inner = inner.map_err(map_cdr_err)?.map_buffer(PyBuf::Owned);
         Ok(Self { inner })
     }
 
@@ -1757,8 +1832,8 @@ impl PyRadarCube {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = RadarCube::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = RadarCube::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -1909,7 +1984,7 @@ impl PyPointField {
 
 #[pyclass(name = "PointCloud2", module = "edgefirst.schemas.sensor_msgs", frozen)]
 pub struct PyPointCloud2 {
-    inner: PointCloud2<Vec<u8>>,
+    inner: PointCloud2<PyBuf>,
 }
 
 #[pymethods]
@@ -1979,7 +2054,7 @@ impl PyPointCloud2 {
         // Keep `fields` alive past the closure boundary: Vec dropped here.
         drop(field_views);
         drop(fields);
-        let inner = inner.map_err(map_cdr_err)?;
+        let inner = inner.map_err(map_cdr_err)?.map_buffer(PyBuf::Owned);
         Ok(Self { inner })
     }
 
@@ -1989,8 +2064,8 @@ impl PyPointCloud2 {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = PointCloud2::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = PointCloud2::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -2086,7 +2161,7 @@ impl PyPointCloud2 {
     frozen
 )]
 pub struct PyFoxgloveCompressedVideo {
-    inner: FoxgloveCompressedVideo<Vec<u8>>,
+    inner: FoxgloveCompressedVideo<PyBuf>,
 }
 
 #[pymethods]
@@ -2114,7 +2189,9 @@ impl PyFoxgloveCompressedVideo {
                 .build()
         });
         let inner = inner.map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -2123,8 +2200,8 @@ impl PyFoxgloveCompressedVideo {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = FoxgloveCompressedVideo::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = FoxgloveCompressedVideo::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -2445,7 +2522,7 @@ macro_rules! stamped_boilerplate {
     ($py_name:ident, $rust_ty:ident, $py_str_name:literal, $mod_name:literal, $payload_getter:ident, $py_payload:ident, $payload_ty:ident, $new_fn:expr, $default_payload:expr) => {
         #[pyclass(name = $py_str_name, module = $mod_name, frozen)]
         pub struct $py_name {
-            inner: $rust_ty<Vec<u8>>,
+            inner: $rust_ty<PyBuf>,
         }
 
         #[pymethods]
@@ -2457,7 +2534,9 @@ macro_rules! stamped_boilerplate {
                 let frame_id = header.inner.frame_id().to_string();
                 let payload = $payload_getter.map(|v| v.0).unwrap_or($default_payload);
                 #[allow(deprecated)]
-                let inner = $new_fn(stamp, &frame_id, payload).map_err(map_cdr_err)?;
+                let inner = $new_fn(stamp, &frame_id, payload)
+                    .map_err(map_cdr_err)?
+                    .map_buffer(PyBuf::Owned);
                 Ok(Self { inner })
             }
 
@@ -2467,8 +2546,8 @@ macro_rules! stamped_boilerplate {
                 _py: Python<'_>,
                 buf: &Bound<'_, PyAny>,
             ) -> PyResult<Self> {
-                let owned = copy_buffer(buf)?;
-                let inner = $rust_ty::from_cdr(owned).map_err(map_cdr_err)?;
+                let pybuf = smart_buffer(buf)?;
+                let inner = $rust_ty::from_cdr(pybuf).map_err(map_cdr_err)?;
                 Ok(Self { inner })
             }
 
@@ -2587,7 +2666,7 @@ stamped_boilerplate!(
     frozen
 )]
 pub struct PyTransformStamped {
-    inner: TransformStamped<Vec<u8>>,
+    inner: TransformStamped<PyBuf>,
 }
 
 #[pymethods]
@@ -2617,7 +2696,9 @@ impl PyTransformStamped {
         #[allow(deprecated)]
         let inner =
             TransformStamped::new(stamp, &frame_id, child_frame_id, t).map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -2626,8 +2707,8 @@ impl PyTransformStamped {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = TransformStamped::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = TransformStamped::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -2662,7 +2743,7 @@ impl PyTransformStamped {
 /// acceleration, each with a 3×3 covariance.
 #[pyclass(name = "Imu", module = "edgefirst.schemas.sensor_msgs", frozen)]
 pub struct PyImu {
-    inner: Imu<Vec<u8>>,
+    inner: Imu<PyBuf>,
 }
 
 #[pymethods]
@@ -2723,7 +2804,9 @@ impl PyImu {
             .linear_acceleration_covariance(lac)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -2732,8 +2815,8 @@ impl PyImu {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Imu::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Imu::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -2783,7 +2866,7 @@ impl PyImu {
 
 #[pyclass(name = "NavSatFix", module = "edgefirst.schemas.sensor_msgs", frozen)]
 pub struct PyNavSatFix {
-    inner: NavSatFix<Vec<u8>>,
+    inner: NavSatFix<PyBuf>,
 }
 
 #[pymethods]
@@ -2825,7 +2908,9 @@ impl PyNavSatFix {
             .position_covariance_type(position_covariance_type)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -2834,8 +2919,8 @@ impl PyNavSatFix {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = NavSatFix::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = NavSatFix::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -2889,7 +2974,7 @@ impl PyNavSatFix {
     frozen
 )]
 pub struct PyMagneticField {
-    inner: MagneticField<Vec<u8>>,
+    inner: MagneticField<PyBuf>,
 }
 
 #[pymethods]
@@ -2916,7 +3001,9 @@ impl PyMagneticField {
             .magnetic_field_covariance(cov)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -2925,8 +3012,8 @@ impl PyMagneticField {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = MagneticField::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = MagneticField::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -2963,7 +3050,7 @@ impl PyMagneticField {
     frozen
 )]
 pub struct PyFluidPressure {
-    inner: FluidPressure<Vec<u8>>,
+    inner: FluidPressure<PyBuf>,
 }
 
 #[pymethods]
@@ -2980,7 +3067,9 @@ impl PyFluidPressure {
             .variance(variance)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -2989,8 +3078,8 @@ impl PyFluidPressure {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = FluidPressure::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = FluidPressure::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3023,7 +3112,7 @@ impl PyFluidPressure {
 
 #[pyclass(name = "Temperature", module = "edgefirst.schemas.sensor_msgs", frozen)]
 pub struct PyTemperature {
-    inner: Temperature<Vec<u8>>,
+    inner: Temperature<PyBuf>,
 }
 
 #[pymethods]
@@ -3040,7 +3129,9 @@ impl PyTemperature {
             .variance(variance)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3049,8 +3140,8 @@ impl PyTemperature {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Temperature::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Temperature::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3083,7 +3174,7 @@ impl PyTemperature {
 
 #[pyclass(name = "CameraInfo", module = "edgefirst.schemas.sensor_msgs", frozen)]
 pub struct PyCameraInfo {
-    inner: CameraInfo<Vec<u8>>,
+    inner: CameraInfo<PyBuf>,
 }
 
 #[pymethods]
@@ -3143,7 +3234,9 @@ impl PyCameraInfo {
             .roi(roi_val)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3152,8 +3245,8 @@ impl PyCameraInfo {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = CameraInfo::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = CameraInfo::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3243,7 +3336,7 @@ fn extract_f64_array<const N: usize>(v: Option<Vec<f64>>) -> PyResult<[f64; N]> 
     frozen
 )]
 pub struct PyBatteryState {
-    inner: BatteryState<Vec<u8>>,
+    inner: BatteryState<PyBuf>,
 }
 
 #[pymethods]
@@ -3309,7 +3402,9 @@ impl PyBatteryState {
             .serial_number(serial_number)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3318,8 +3413,8 @@ impl PyBatteryState {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = BatteryState::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = BatteryState::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3404,7 +3499,7 @@ impl PyBatteryState {
 
 #[pyclass(name = "Odometry", module = "edgefirst.schemas.nav_msgs", frozen)]
 pub struct PyOdometry {
-    inner: Odometry<Vec<u8>>,
+    inner: Odometry<PyBuf>,
 }
 
 #[pymethods]
@@ -3455,7 +3550,9 @@ impl PyOdometry {
         // public constructor for this type).
         #[allow(deprecated)]
         let inner = Odometry::new(stamp, &frame_id, child_frame_id, p, t).map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3464,8 +3561,8 @@ impl PyOdometry {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Odometry::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Odometry::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3515,7 +3612,7 @@ impl PyOdometry {
     frozen
 )]
 pub struct PyLocalTime {
-    inner: LocalTime<Vec<u8>>,
+    inner: LocalTime<PyBuf>,
 }
 
 #[pymethods]
@@ -3544,7 +3641,9 @@ impl PyLocalTime {
             .timezone(timezone)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3553,8 +3652,8 @@ impl PyLocalTime {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = LocalTime::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = LocalTime::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3591,7 +3690,7 @@ impl PyLocalTime {
 
 #[pyclass(name = "Track", module = "edgefirst.schemas.edgefirst_msgs", frozen)]
 pub struct PyTrack {
-    inner: Track<Vec<u8>>,
+    inner: Track<PyBuf>,
 }
 
 #[pymethods]
@@ -3606,7 +3705,9 @@ impl PyTrack {
             .created(c)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3615,8 +3716,8 @@ impl PyTrack {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Track::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Track::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3649,7 +3750,7 @@ impl PyTrack {
     frozen
 )]
 pub struct PyRadarInfo {
-    inner: RadarInfo<Vec<u8>>,
+    inner: RadarInfo<PyBuf>,
 }
 
 #[pymethods]
@@ -3676,7 +3777,9 @@ impl PyRadarInfo {
             .cube(cube)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3685,8 +3788,8 @@ impl PyRadarInfo {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = RadarInfo::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = RadarInfo::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3735,7 +3838,7 @@ impl PyRadarInfo {
     frozen
 )]
 pub struct PyVibration {
-    inner: Vibration<Vec<u8>>,
+    inner: Vibration<PyBuf>,
 }
 
 #[pymethods]
@@ -3778,7 +3881,9 @@ impl PyVibration {
             .clipping(&clip)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3787,8 +3892,8 @@ impl PyVibration {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Vibration::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Vibration::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -3841,7 +3946,7 @@ impl PyVibration {
     frozen
 )]
 pub struct PyModelInfo {
-    inner: ModelInfo<Vec<u8>>,
+    inner: ModelInfo<PyBuf>,
 }
 
 #[pymethods]
@@ -3888,7 +3993,9 @@ impl PyModelInfo {
             .model_name(model_name)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -3897,8 +4004,8 @@ impl PyModelInfo {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = ModelInfo::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = ModelInfo::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -4096,7 +4203,7 @@ impl PyDetectBox {
 
 #[pyclass(name = "Detect", module = "edgefirst.schemas.edgefirst_msgs", frozen)]
 pub struct PyDetect {
-    inner: Detect<Vec<u8>>,
+    inner: Detect<PyBuf>,
 }
 
 #[pymethods]
@@ -4140,7 +4247,9 @@ impl PyDetect {
             .boxes(&box_views)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -4149,8 +4258,8 @@ impl PyDetect {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Detect::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Detect::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -4294,7 +4403,7 @@ impl PyCameraPlane {
     frozen
 )]
 pub struct PyCameraFrame {
-    inner: CameraFrame<Vec<u8>>,
+    inner: CameraFrame<PyBuf>,
 }
 
 #[pymethods]
@@ -4350,7 +4459,9 @@ impl PyCameraFrame {
             .planes(&plane_views)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -4359,8 +4470,8 @@ impl PyCameraFrame {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = CameraFrame::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = CameraFrame::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -4521,7 +4632,7 @@ impl PyMaskBox {
 
 #[pyclass(name = "Model", module = "edgefirst.schemas.edgefirst_msgs", frozen)]
 pub struct PyModel {
-    inner: Model<Vec<u8>>,
+    inner: Model<PyBuf>,
 }
 
 #[pymethods]
@@ -4571,7 +4682,9 @@ impl PyModel {
             .masks(&mask_views)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -4580,8 +4693,8 @@ impl PyModel {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = Model::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = Model::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -4802,7 +4915,7 @@ impl PyFoxgloveCircleAnnotations {
     frozen
 )]
 pub struct PyFoxgloveTextAnnotation {
-    inner: FoxgloveTextAnnotation<Vec<u8>>,
+    inner: FoxgloveTextAnnotation<PyBuf>,
 }
 
 #[pymethods]
@@ -4847,7 +4960,9 @@ impl PyFoxgloveTextAnnotation {
             .background_color(bc)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -4856,8 +4971,8 @@ impl PyFoxgloveTextAnnotation {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = FoxgloveTextAnnotation::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = FoxgloveTextAnnotation::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -4903,7 +5018,7 @@ impl PyFoxgloveTextAnnotation {
     frozen
 )]
 pub struct PyFoxglovePointAnnotation {
-    inner: FoxglovePointAnnotation<Vec<u8>>,
+    inner: FoxglovePointAnnotation<PyBuf>,
 }
 
 #[pymethods]
@@ -4953,7 +5068,9 @@ impl PyFoxglovePointAnnotation {
             .thickness(thickness)
             .build()
             .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -4962,8 +5079,8 @@ impl PyFoxglovePointAnnotation {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = FoxglovePointAnnotation::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = FoxglovePointAnnotation::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5026,7 +5143,8 @@ fn text_annotation_view_to_py(
         .text_color(v.text_color)
         .background_color(v.background_color)
         .build()
-        .map_err(map_cdr_err)?;
+        .map_err(map_cdr_err)?
+        .map_buffer(PyBuf::Owned);
     Ok(PyFoxgloveTextAnnotation { inner })
 }
 
@@ -5043,7 +5161,8 @@ fn point_annotation_view_to_py(
         .fill_color(v.fill_color)
         .thickness(v.thickness)
         .build()
-        .map_err(map_cdr_err)?;
+        .map_err(map_cdr_err)?
+        .map_buffer(PyBuf::Owned);
     Ok(PyFoxglovePointAnnotation { inner })
 }
 
@@ -5053,7 +5172,7 @@ fn point_annotation_view_to_py(
     frozen
 )]
 pub struct PyFoxgloveImageAnnotation {
-    inner: FoxgloveImageAnnotation<Vec<u8>>,
+    inner: FoxgloveImageAnnotation<PyBuf>,
 }
 
 #[pymethods]
@@ -5114,7 +5233,8 @@ impl PyFoxgloveImageAnnotation {
             .points(&point_views)
             .texts(&text_views)
             .build()
-            .map_err(map_cdr_err)?;
+            .map_err(map_cdr_err)?
+            .map_buffer(PyBuf::Owned);
         Ok(Self { inner })
     }
 
@@ -5124,8 +5244,8 @@ impl PyFoxgloveImageAnnotation {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = FoxgloveImageAnnotation::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = FoxgloveImageAnnotation::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5166,7 +5286,7 @@ impl PyFoxgloveImageAnnotation {
 
 #[pyclass(name = "Altitude", module = "edgefirst.schemas.mavros_msgs", frozen)]
 pub struct PyMavrosAltitude {
-    inner: MavAltitude<Vec<u8>>,
+    inner: MavAltitude<PyBuf>,
 }
 
 #[pymethods]
@@ -5193,7 +5313,9 @@ impl PyMavrosAltitude {
             bottom_clearance,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5202,8 +5324,8 @@ impl PyMavrosAltitude {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = MavAltitude::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = MavAltitude::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5250,7 +5372,7 @@ impl PyMavrosAltitude {
 
 #[pyclass(name = "VfrHud", module = "edgefirst.schemas.mavros_msgs", frozen)]
 pub struct PyMavrosVfrHud {
-    inner: VfrHud<Vec<u8>>,
+    inner: VfrHud<PyBuf>,
 }
 
 #[pymethods]
@@ -5277,7 +5399,9 @@ impl PyMavrosVfrHud {
             climb,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5286,8 +5410,8 @@ impl PyMavrosVfrHud {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = VfrHud::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = VfrHud::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5338,7 +5462,7 @@ impl PyMavrosVfrHud {
     frozen
 )]
 pub struct PyMavrosEstimatorStatus {
-    inner: EstimatorStatus<Vec<u8>>,
+    inner: EstimatorStatus<PyBuf>,
 }
 
 #[pymethods]
@@ -5377,7 +5501,9 @@ impl PyMavrosEstimatorStatus {
             accel_error_status_flag,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5386,8 +5512,8 @@ impl PyMavrosEstimatorStatus {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = EstimatorStatus::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = EstimatorStatus::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5462,7 +5588,7 @@ impl PyMavrosEstimatorStatus {
     frozen
 )]
 pub struct PyMavrosExtendedState {
-    inner: ExtendedState<Vec<u8>>,
+    inner: ExtendedState<PyBuf>,
 }
 
 #[pymethods]
@@ -5500,7 +5626,9 @@ impl PyMavrosExtendedState {
             landed_state,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5509,8 +5637,8 @@ impl PyMavrosExtendedState {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = ExtendedState::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = ExtendedState::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5541,7 +5669,7 @@ impl PyMavrosExtendedState {
 
 #[pyclass(name = "SysStatus", module = "edgefirst.schemas.mavros_msgs", frozen)]
 pub struct PyMavrosSysStatus {
-    inner: SysStatus<Vec<u8>>,
+    inner: SysStatus<PyBuf>,
 }
 
 #[pymethods]
@@ -5582,7 +5710,9 @@ impl PyMavrosSysStatus {
             errors_count4,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5591,8 +5721,8 @@ impl PyMavrosSysStatus {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = SysStatus::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = SysStatus::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5667,7 +5797,7 @@ impl PyMavrosSysStatus {
 
 #[pyclass(name = "State", module = "edgefirst.schemas.mavros_msgs", frozen)]
 pub struct PyMavrosState {
-    inner: MavState<Vec<u8>>,
+    inner: MavState<PyBuf>,
 }
 
 #[pymethods]
@@ -5713,7 +5843,9 @@ impl PyMavrosState {
             system_status,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5722,8 +5854,8 @@ impl PyMavrosState {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = MavState::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = MavState::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5770,7 +5902,7 @@ impl PyMavrosState {
 
 #[pyclass(name = "StatusText", module = "edgefirst.schemas.mavros_msgs", frozen)]
 pub struct PyMavrosStatusText {
-    inner: StatusText<Vec<u8>>,
+    inner: StatusText<PyBuf>,
 }
 
 #[pymethods]
@@ -5802,7 +5934,9 @@ impl PyMavrosStatusText {
             text,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5811,8 +5945,8 @@ impl PyMavrosStatusText {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = StatusText::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = StatusText::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -5843,7 +5977,7 @@ impl PyMavrosStatusText {
 
 #[pyclass(name = "GpsRaw", module = "edgefirst.schemas.mavros_msgs", frozen)]
 pub struct PyMavrosGpsRaw {
-    inner: GpsRaw<Vec<u8>>,
+    inner: GpsRaw<PyBuf>,
 }
 
 #[pymethods]
@@ -5911,7 +6045,9 @@ impl PyMavrosGpsRaw {
             dgps_age,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -5920,8 +6056,8 @@ impl PyMavrosGpsRaw {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = GpsRaw::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = GpsRaw::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 
@@ -6016,7 +6152,7 @@ impl PyMavrosGpsRaw {
     frozen
 )]
 pub struct PyMavrosTimesyncStatus {
-    inner: TimesyncStatus<Vec<u8>>,
+    inner: TimesyncStatus<PyBuf>,
 }
 
 #[pymethods]
@@ -6039,7 +6175,9 @@ impl PyMavrosTimesyncStatus {
             round_trip_time_ms,
         )
         .map_err(map_cdr_err)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: inner.map_buffer(PyBuf::Owned),
+        })
     }
 
     #[classmethod]
@@ -6048,8 +6186,8 @@ impl PyMavrosTimesyncStatus {
         _py: Python<'_>,
         buf: &Bound<'_, PyAny>,
     ) -> PyResult<Self> {
-        let owned = copy_buffer(buf)?;
-        let inner = TimesyncStatus::from_cdr(owned).map_err(map_cdr_err)?;
+        let pybuf = smart_buffer(buf)?;
+        let inner = TimesyncStatus::from_cdr(pybuf).map_err(map_cdr_err)?;
         Ok(Self { inner })
     }
 

--- a/src/edgefirst_msgs.rs
+++ b/src/edgefirst_msgs.rs
@@ -86,6 +86,17 @@ pub struct Mask<B> {
     offsets: [usize; 2],
 }
 
+impl<B> Mask<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Mask<C> {
+        Mask {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> Mask<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let mut c = CdrCursor::new(buf.as_ref())?;
@@ -402,6 +413,18 @@ pub struct DmaBuffer<B> {
     offsets: [usize; 1],
 }
 
+#[allow(deprecated)]
+impl<B> DmaBuffer<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> DmaBuffer<C> {
+        DmaBuffer {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 // The DmaBuffer impls remain until 4.0.0; allow(deprecated) here so the
 // crate's own use of the deprecated struct (fields, methods) compiles
 // cleanly. User code still gets the deprecation warning.
@@ -534,6 +557,17 @@ impl DmaBuffer<Vec<u8>> {
 pub struct LocalTime<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> LocalTime<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> LocalTime<C> {
+        LocalTime {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> LocalTime<B> {
@@ -775,6 +809,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> LocalTime<B> {
 pub struct RadarCube<B> {
     buf: B,
     offsets: [usize; 5],
+}
+
+impl<B> RadarCube<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> RadarCube<C> {
+        RadarCube {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> RadarCube<B> {
@@ -1096,6 +1141,17 @@ pub struct RadarInfo<B> {
     offsets: [usize; 5],
 }
 
+impl<B> RadarInfo<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> RadarInfo<C> {
+        RadarInfo {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> RadarInfo<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -1345,6 +1401,17 @@ pub struct Track<B> {
     offsets: [usize; 1],
 }
 
+impl<B> Track<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Track<C> {
+        Track {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> Track<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let mut c = CdrCursor::new(buf.as_ref())?;
@@ -1516,6 +1583,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Track<B> {
 pub struct DetectBox<B> {
     buf: B,
     offsets: [usize; 2],
+}
+
+impl<B> DetectBox<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> DetectBox<C> {
+        DetectBox {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 /// Zero-copy view of a Box element within a CDR sequence.
@@ -1934,6 +2012,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> DetectBox<B> {
 pub struct Detect<B> {
     buf: B,
     offsets: [usize; 2],
+}
+
+impl<B> Detect<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Detect<C> {
+        Detect {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> Detect<B> {
@@ -2366,6 +2455,17 @@ pub struct CameraFrame<B> {
     // variable-length colorimetry strings on every `planes()`/`num_planes()`
     // call — important for high-frame-rate consumers.
     offsets: [usize; 2],
+}
+
+impl<B> CameraFrame<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> CameraFrame<C> {
+        CameraFrame {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> CameraFrame<B> {
@@ -2884,6 +2984,17 @@ pub struct Model<B> {
     offsets: [usize; 3],
 }
 
+impl<B> Model<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Model<C> {
+        Model {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> Model<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -3277,6 +3388,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> Model<B> {
 pub struct ModelInfo<B> {
     buf: B,
     offsets: [usize; 6],
+}
+
+impl<B> ModelInfo<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> ModelInfo<C> {
+        ModelInfo {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> ModelInfo<B> {
@@ -3677,6 +3799,17 @@ pub struct Vibration<B> {
     // offsets[0] is 8-aligned (hence 4-aligned relative to CDR payload
     // start). No position-dependent padding anywhere.
     offsets: [usize; 1],
+}
+
+impl<B> Vibration<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Vibration<C> {
+        Vibration {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> Vibration<B> {

--- a/src/foxglove_msgs.rs
+++ b/src/foxglove_msgs.rs
@@ -136,6 +136,17 @@ pub struct FoxgloveCompressedVideo<B> {
     offsets: [usize; 3],
 }
 
+impl<B> FoxgloveCompressedVideo<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> FoxgloveCompressedVideo<C> {
+        FoxgloveCompressedVideo {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> FoxgloveCompressedVideo<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -354,6 +365,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> FoxgloveCompressedVideo<B> {
 pub struct FoxgloveTextAnnotation<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> FoxgloveTextAnnotation<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> FoxgloveTextAnnotation<C> {
+        FoxgloveTextAnnotation {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 /// View of a FoxgloveTextAnnotations element within a CDR sequence.
@@ -662,6 +684,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> FoxgloveTextAnnotation<B> {
 pub struct FoxglovePointAnnotation<B> {
     buf: B,
     offsets: [usize; 2],
+}
+
+impl<B> FoxglovePointAnnotation<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> FoxglovePointAnnotation<C> {
+        FoxglovePointAnnotation {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 /// View of a FoxglovePointAnnotations element within a CDR sequence.
@@ -1063,6 +1096,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> FoxglovePointAnnotation<B> {
 pub struct FoxgloveImageAnnotation<B> {
     buf: B,
     offsets: [usize; 2],
+}
+
+impl<B> FoxgloveImageAnnotation<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> FoxgloveImageAnnotation<C> {
+        FoxgloveImageAnnotation {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> FoxgloveImageAnnotation<B> {

--- a/src/geometry_msgs.rs
+++ b/src/geometry_msgs.rs
@@ -377,6 +377,17 @@ pub struct AccelStamped<B> {
     offsets: [usize; 1],
 }
 
+impl<B> AccelStamped<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> AccelStamped<C> {
+        AccelStamped {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> AccelStamped<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -442,6 +453,17 @@ impl AccelStamped<Vec<u8>> {
 pub struct TwistStamped<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> TwistStamped<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> TwistStamped<C> {
+        TwistStamped {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> TwistStamped<B> {
@@ -511,6 +533,17 @@ pub struct InertiaStamped<B> {
     offsets: [usize; 1],
 }
 
+impl<B> InertiaStamped<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> InertiaStamped<C> {
+        InertiaStamped {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> InertiaStamped<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -576,6 +609,17 @@ impl InertiaStamped<Vec<u8>> {
 pub struct PointStamped<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> PointStamped<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> PointStamped<C> {
+        PointStamped {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> PointStamped<B> {
@@ -646,6 +690,17 @@ impl PointStamped<Vec<u8>> {
 pub struct TransformStamped<B> {
     buf: B,
     offsets: [usize; 2],
+}
+
+impl<B> TransformStamped<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> TransformStamped<C> {
+        TransformStamped {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> TransformStamped<B> {

--- a/src/mavros_msgs.rs
+++ b/src/mavros_msgs.rs
@@ -30,6 +30,17 @@ pub struct Altitude<B> {
     offsets: [usize; 1],
 }
 
+impl<B> Altitude<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Altitude<C> {
+        Altitude {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> Altitude<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -153,6 +164,17 @@ pub struct VfrHud<B> {
     offsets: [usize; 1],
 }
 
+impl<B> VfrHud<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> VfrHud<C> {
+        VfrHud {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> VfrHud<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -267,6 +289,17 @@ impl VfrHud<Vec<u8>> {
 pub struct EstimatorStatus<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> EstimatorStatus<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> EstimatorStatus<C> {
+        EstimatorStatus {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> EstimatorStatus<B> {
@@ -430,6 +463,17 @@ pub struct ExtendedState<B> {
     offsets: [usize; 1],
 }
 
+impl<B> ExtendedState<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> ExtendedState<C> {
+        ExtendedState {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> ExtendedState<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -527,6 +571,17 @@ impl ExtendedState<Vec<u8>> {
 pub struct SysStatus<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> SysStatus<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> SysStatus<C> {
+        SysStatus {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> SysStatus<B> {
@@ -736,6 +791,17 @@ pub struct State<B> {
     offsets: [usize; 3],
 }
 
+impl<B> State<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> State<C> {
+        State {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> State<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -874,6 +940,17 @@ pub struct StatusText<B> {
     offsets: [usize; 2],
 }
 
+impl<B> StatusText<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> StatusText<C> {
+        StatusText {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> StatusText<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -996,6 +1073,17 @@ pub mod gps_fix_type {
 pub struct GpsRaw<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> GpsRaw<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> GpsRaw<C> {
+        GpsRaw {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> GpsRaw<B> {
@@ -1230,6 +1318,17 @@ impl GpsRaw<Vec<u8>> {
 pub struct TimesyncStatus<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> TimesyncStatus<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> TimesyncStatus<C> {
+        TimesyncStatus {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> TimesyncStatus<B> {

--- a/src/nav_msgs.rs
+++ b/src/nav_msgs.rs
@@ -30,6 +30,17 @@ pub struct Odometry<B> {
     offsets: [usize; 3],
 }
 
+impl<B> Odometry<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Odometry<C> {
+        Odometry {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> Odometry<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;

--- a/src/sensor_msgs/mod.rs
+++ b/src/sensor_msgs/mod.rs
@@ -228,6 +228,17 @@ pub struct CompressedImage<B> {
     offsets: [usize; 3],
 }
 
+impl<B> CompressedImage<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> CompressedImage<C> {
+        CompressedImage {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> CompressedImage<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -423,6 +434,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> CompressedImage<B> {
 pub struct Image<B> {
     buf: B,
     offsets: [usize; 3],
+}
+
+impl<B> Image<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Image<C> {
+        Image {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> Image<B> {
@@ -720,6 +742,17 @@ impl<'a> ImageBuilder<'a> {
 pub struct Imu<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> Imu<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Imu<C> {
+        Imu {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> Imu<B> {
@@ -1052,6 +1085,17 @@ pub struct NavSatFix<B> {
     offsets: [usize; 2],
 }
 
+impl<B> NavSatFix<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> NavSatFix<C> {
+        NavSatFix {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> NavSatFix<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -1358,6 +1402,17 @@ pub struct PointField<B> {
     offsets: [usize; 1],
 }
 
+impl<B> PointField<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> PointField<C> {
+        PointField {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> PointField<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let mut c = CdrCursor::new(buf.as_ref())?;
@@ -1561,6 +1616,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> PointField<B> {
 pub struct PointCloud2<B> {
     buf: B,
     offsets: [usize; 3],
+}
+
+impl<B> PointCloud2<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> PointCloud2<C> {
+        PointCloud2 {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> PointCloud2<B> {
@@ -1939,6 +2005,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> PointCloud2<B> {
 pub struct CameraInfo<B> {
     buf: B,
     offsets: [usize; 3],
+}
+
+impl<B> CameraInfo<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> CameraInfo<C> {
+        CameraInfo {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> CameraInfo<B> {
@@ -2377,6 +2454,17 @@ pub struct MagneticField<B> {
     offsets: [usize; 1],
 }
 
+impl<B> MagneticField<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> MagneticField<C> {
+        MagneticField {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> MagneticField<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -2580,6 +2668,17 @@ pub struct FluidPressure<B> {
     offsets: [usize; 1],
 }
 
+impl<B> FluidPressure<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> FluidPressure<C> {
+        FluidPressure {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> FluidPressure<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let header = Header::<&[u8]>::from_cdr(buf.as_ref())?;
@@ -2765,6 +2864,17 @@ impl<B: AsRef<[u8]> + AsMut<[u8]>> FluidPressure<B> {
 pub struct Temperature<B> {
     buf: B,
     offsets: [usize; 1],
+}
+
+impl<B> Temperature<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Temperature<C> {
+        Temperature {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> Temperature<B> {
@@ -2999,6 +3109,17 @@ pub struct BatteryState<B> {
     // [3]: start of location string.
     // [4]: start of serial_number string.
     offsets: [usize; 5],
+}
+
+impl<B> BatteryState<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> BatteryState<C> {
+        BatteryState {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
 }
 
 impl<B: AsRef<[u8]>> BatteryState<B> {

--- a/src/std_msgs.rs
+++ b/src/std_msgs.rs
@@ -57,6 +57,17 @@ pub struct Header<B> {
     offsets: [usize; 1],
 }
 
+impl<B> Header<B> {
+    /// Convert the buffer type without re-parsing the offset table.
+    #[inline]
+    pub fn map_buffer<C>(self, f: impl FnOnce(B) -> C) -> Header<C> {
+        Header {
+            buf: f(self.buf),
+            offsets: self.offsets,
+        }
+    }
+}
+
 impl<B: AsRef<[u8]>> Header<B> {
     pub fn from_cdr(buf: B) -> Result<Self, CdrError> {
         let mut c = CdrCursor::new(buf.as_ref())?;

--- a/tests/python/test_zero_copy_input.py
+++ b/tests/python/test_zero_copy_input.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2026 Au-Zone Technologies. All Rights Reserved.
+
+"""Tests for zero-copy ``from_cdr`` input path.
+
+The optimization:
+- ``from_cdr(bytes)`` borrows the input zero-copy (no memcpy).
+- ``from_cdr(bytearray)`` copies (GIL safety for mutable buffers).
+- ``from_cdr(memoryview)`` copies (same reason).
+
+These tests validate:
+1. Correctness: from_cdr produces valid messages from both paths.
+2. Isolation: mutable-source messages are unaffected by later mutations.
+3. Zero-copy proof: bytes-backed messages share the underlying buffer.
+4. Lifetime safety: messages remain valid after the source is unreferenced.
+"""
+
+import gc
+import sys
+
+import pytest
+
+from edgefirst.schemas.builtin_interfaces import Time
+from edgefirst.schemas.sensor_msgs import Image, CompressedImage, Imu
+from edgefirst.schemas.std_msgs import Header
+from edgefirst.schemas.geometry_msgs import TwistStamped
+
+
+def _make_image_cdr() -> bytes:
+    """Build a valid Image CDR buffer via the constructor path."""
+    img = Image(
+        header=Header(stamp=Time(42, 100), frame_id="cam0"),
+        height=2,
+        width=2,
+        encoding="mono8",
+        is_bigendian=0,
+        step=2,
+        data=b"\x01\x02\x03\x04",
+    )
+    return img.to_bytes()
+
+
+def _make_imu_cdr() -> bytes:
+    """Build a valid Imu CDR buffer."""
+    imu = Imu(header=Header(stamp=Time(1, 0), frame_id="imu"))
+    return imu.to_bytes()
+
+
+def _make_twist_cdr() -> bytes:
+    """Build a valid TwistStamped CDR buffer."""
+    tw = TwistStamped(header=Header(stamp=Time(5, 500), frame_id="base"))
+    return tw.to_bytes()
+
+
+class TestFromCdrBytes:
+    """from_cdr(bytes) should be zero-copy (no memcpy of the buffer)."""
+
+    def test_image_from_bytes(self):
+        cdr = _make_image_cdr()
+        img = Image.from_cdr(cdr)
+        assert img.height == 2
+        assert img.width == 2
+        assert img.encoding == "mono8"
+        assert img.data.tobytes() == b"\x01\x02\x03\x04"
+
+    def test_imu_from_bytes(self):
+        cdr = _make_imu_cdr()
+        imu = Imu.from_cdr(cdr)
+        assert imu.frame_id == "imu"
+        assert imu.stamp == Time(1, 0)
+
+    def test_twist_from_bytes(self):
+        cdr = _make_twist_cdr()
+        tw = TwistStamped.from_cdr(cdr)
+        assert tw.frame_id == "base"
+
+    def test_zero_copy_shares_buffer(self):
+        """Prove that from_cdr(bytes) does NOT copy the input.
+
+        We verify by checking that the CDR output (to_bytes) matches the
+        input exactly, and that the message remains valid even if we delete
+        our local reference to the input bytes (the message holds its own
+        strong reference to the bytes object).
+        """
+        cdr = _make_image_cdr()
+        img = Image.from_cdr(cdr)
+        # The message's CDR representation should be byte-identical to input
+        assert img.to_bytes() == cdr
+
+    def test_message_valid_after_source_unreferenced(self):
+        """Message stays valid after the original bytes is GC'd."""
+        cdr = _make_image_cdr()
+        img = Image.from_cdr(cdr)
+        # Delete our reference to the source bytes
+        del cdr
+        gc.collect()
+        # Message should still be fully accessible
+        assert img.height == 2
+        assert img.width == 2
+        assert img.encoding == "mono8"
+        assert img.data.tobytes() == b"\x01\x02\x03\x04"
+        assert img.stamp == Time(42, 100)
+
+    def test_multiple_messages_from_same_bytes(self):
+        """Multiple from_cdr calls on the same bytes are independent."""
+        cdr = _make_image_cdr()
+        img1 = Image.from_cdr(cdr)
+        img2 = Image.from_cdr(cdr)
+        assert img1.height == img2.height
+        assert img1.data.tobytes() == img2.data.tobytes()
+
+
+class TestFromCdrBytearray:
+    """from_cdr(bytearray) should copy for GIL safety."""
+
+    def test_image_from_bytearray(self):
+        cdr = bytearray(_make_image_cdr())
+        img = Image.from_cdr(cdr)
+        assert img.height == 2
+        assert img.encoding == "mono8"
+
+    def test_mutation_after_from_cdr_does_not_affect_message(self):
+        """After from_cdr(bytearray), mutating the bytearray is safe."""
+        cdr = bytearray(_make_image_cdr())
+        img = Image.from_cdr(cdr)
+        # Corrupt the source
+        cdr[:] = b"\x00" * len(cdr)
+        # Message must be unaffected
+        assert img.height == 2
+        assert img.width == 2
+        assert img.encoding == "mono8"
+        assert img.data.tobytes() == b"\x01\x02\x03\x04"
+
+    def test_imu_from_bytearray_isolated(self):
+        cdr = bytearray(_make_imu_cdr())
+        imu = Imu.from_cdr(cdr)
+        cdr[:] = b"\xff" * len(cdr)
+        assert imu.frame_id == "imu"
+
+
+class TestFromCdrMemoryview:
+    """from_cdr(memoryview) should copy (mutable source)."""
+
+    def test_image_from_memoryview(self):
+        cdr = memoryview(_make_image_cdr())
+        img = Image.from_cdr(cdr)
+        assert img.height == 2
+        assert img.encoding == "mono8"
+
+    def test_readonly_memoryview_from_bytes(self):
+        """Readonly memoryview over bytes should still work."""
+        cdr = _make_image_cdr()
+        mv = memoryview(cdr)
+        img = Image.from_cdr(mv)
+        assert img.height == 2
+
+    def test_mutable_memoryview_isolated(self):
+        """Mutable memoryview: mutation after from_cdr doesn't affect msg."""
+        source = bytearray(_make_image_cdr())
+        mv = memoryview(source)
+        img = Image.from_cdr(mv)
+        source[:] = b"\x00" * len(source)
+        assert img.height == 2
+        assert img.data.tobytes() == b"\x01\x02\x03\x04"
+
+
+class TestCdrRoundTrip:
+    """Verify from_cdr → to_bytes round-trip for both input paths."""
+
+    def test_bytes_round_trip(self):
+        cdr = _make_image_cdr()
+        img = Image.from_cdr(cdr)
+        assert img.to_bytes() == cdr
+
+    def test_bytearray_round_trip(self):
+        cdr_bytes = _make_image_cdr()
+        cdr_ba = bytearray(cdr_bytes)
+        img = Image.from_cdr(cdr_ba)
+        assert img.to_bytes() == cdr_bytes
+
+    def test_compressed_image_round_trip(self):
+        ci = CompressedImage(
+            header=Header(stamp=Time(1, 0), frame_id="c"),
+            format="jpeg",
+            data=b"\xff\xd8\xff\xe0",
+        )
+        cdr = ci.to_bytes()
+        ci2 = CompressedImage.from_cdr(cdr)
+        assert ci2.format == "jpeg"
+        assert ci2.data.tobytes() == b"\xff\xd8\xff\xe0"
+        assert ci2.to_bytes() == cdr

--- a/tests/python/test_zero_copy_input.py
+++ b/tests/python/test_zero_copy_input.py
@@ -15,10 +15,8 @@ These tests validate:
 4. Lifetime safety: messages remain valid after the source is unreferenced.
 """
 
+import ctypes
 import gc
-import sys
-
-import pytest
 
 from edgefirst.schemas.builtin_interfaces import Time
 from edgefirst.schemas.sensor_msgs import Image, CompressedImage, Imu
@@ -75,17 +73,44 @@ class TestFromCdrBytes:
         assert tw.frame_id == "base"
 
     def test_zero_copy_shares_buffer(self):
-        """Prove that from_cdr(bytes) does NOT copy the input.
+        """Prove that from_cdr(bytes) aliases the input buffer.
 
-        We verify by checking that the CDR output (to_bytes) matches the
-        input exactly, and that the message remains valid even if we delete
-        our local reference to the input bytes (the message holds its own
-        strong reference to the bytes object).
+        We mutate the underlying bytes memory via ctypes and observe the
+        change through the message's accessor — proving the message reads
+        directly from the input bytes without any intermediate copy.
+
+        NOTE: mutating a `bytes` object is undefined behavior in Python,
+        but it's the only way to prove true aliasing in a test. This test
+        is purely diagnostic — production code must never mutate bytes.
         """
         cdr = _make_image_cdr()
         img = Image.from_cdr(cdr)
-        # The message's CDR representation should be byte-identical to input
-        assert img.to_bytes() == cdr
+
+        # Read the original height (should be 2)
+        assert img.height == 2
+
+        # Get writable access to the bytes buffer via CPython internals.
+        # PyBytes_AsString returns a char* to the internal buffer.
+        PyBytes_AsString = ctypes.pythonapi.PyBytes_AsString
+        PyBytes_AsString.restype = ctypes.POINTER(ctypes.c_ubyte)
+        PyBytes_AsString.argtypes = [ctypes.py_object]
+        buf = PyBytes_AsString(cdr)
+
+        # Find the height field (u32 LE value 2) in the CDR buffer.
+        # Scan for the pattern to be robust against header size changes.
+        height_le = (2).to_bytes(4, "little")
+        raw = bytes(cdr)
+        offset = raw.find(height_le)
+        assert offset >= 0, "Could not locate height field in CDR"
+
+        # Overwrite height to 99 (u32 LE: 0x63 0x00 0x00 0x00)
+        buf[offset] = 99
+        buf[offset + 1] = 0
+        buf[offset + 2] = 0
+        buf[offset + 3] = 0
+
+        # The message should now see height=99 — proving zero-copy aliasing
+        assert img.height == 99
 
     def test_message_valid_after_source_unreferenced(self):
         """Message stays valid after the original bytes is GC'd."""


### PR DESCRIPTION
## JIRA Ticket
Link: [EDGEAI-1291](https://au-zone.atlassian.net/browse/EDGEAI-1291)

## Changes

Eliminates a memcpy on the Python `from_cdr()` hot path when the input is an immutable `bytes` object. This is significant for high-frequency/large messages (camera frames, point clouds, radar cubes) where the CDR buffer can be referenced directly.

### Core crate
- Add `map_buffer()` to all 43 buffer-backed schema types — enables O(1) buffer-type conversion without re-parsing the offset table

### Python crate
- Introduce `PyBuf` enum: `Owned(Vec<u8>)` | `Borrowed { obj: Py<PyBytes>, ptr, len }`
- `smart_buffer()` helper detects `bytes` → zero-copy borrow, else → safe copy
- All 38 Python wrapper types changed from `Type<Vec<u8>>` to `Type<PyBuf>`
- Builder `new()` paths use `.map_buffer(PyBuf::Owned)` for the conversion

### Behavior matrix

| Input type | `from_cdr` behavior | Safety rationale |
|---|---|---|
| `bytes` | Zero-copy borrow | Immutable; refcount prevents GC |
| `bytearray` | Copy under GIL | Mutable; prevents data races |
| `memoryview` | Copy under GIL | May alias mutable buffer |

### Tests
- 15 new tests in `test_zero_copy_input.py` covering:
  - Correctness from bytes/bytearray/memoryview
  - Isolation (mutation after from_cdr does not affect message)
  - Lifetime safety (message valid after source bytes GC'd)
  - CDR round-trip preservation

## Testing
- [x] Rust: 344 tests pass (cargo nextest)
- [x] C: 166 tests pass (make test-c)
- [x] C++: 84 assertions in 16 test cases (make test-cpp)
- [x] Python: 213 tests pass (pytest) — includes 15 new zero-copy tests
- [x] cargo fmt + clippy clean

## Checklist
- [x] Code follows project conventions
- [x] Zero-copy contract maintained
- [x] Documentation updated (module docstring)
- [x] No secrets or credentials committed
- [x] License policy compliance (no new dependencies)

[EDGEAI-1291]: https://au-zone.atlassian.net/browse/EDGEAI-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ