### PR TITLE
DE-2667: Fix spelling typos in the message docstrings

### DIFF
--- a/benches/python/legacy/edgefirst_msgs.py
+++ b/benches/python/legacy/edgefirst_msgs.py
@@ -385,9 +385,9 @@ class RadarChannel(Enum):
 @dataclass
 class RadarCube(IdlStruct, typename='edgefirst_msgs/RadarCube'):
     """
-    The RadarCube interface carries various radar cube reprensentations of the
+    The RadarCube interface carries various radar cube representations of the
     Radar FFT before generally being processed by CFAR into a point cloud.  The
-    cube coud be R, RD, RAD, RA, and so on where R=Range, D=Dopper, and
+    cube could be R, RD, RAD, RA, and so on where R=Range, D=Doppler, and
     A=Azimuth.
 
     Dimensional labels are used to describe the radar cube layout.  Not all

--- a/benches/python/legacy/sensor_msgs.py
+++ b/benches/python/legacy/sensor_msgs.py
@@ -229,7 +229,7 @@ class CameraInfo(IdlStruct, typename='sensor_msgs/CameraInfo'):
     """
     The distortion model used. Supported models are listed in
     sensor_msgs/distortion_models.hpp. For most cameras, "plumb_bob" - a
-    simple model of radial and tangential distortion - is sufficent.
+    simple model of radial and tangential distortion - is sufficient.
     """
 
     d: sequence[float64] = default_field([])
@@ -358,7 +358,7 @@ class CompressedImage(IdlStruct, typename='sensor_msgs/CompressedImage'):
     """
     Header timestamp should be acquisition time of image
     Header frame_id should be optical frame of camera
-    origin of frame should be optical center of cameara
+    origin of frame should be optical center of camera
     +x should point to the right in the image
     +y should point down in the image
     +z should point into to plane of the image
@@ -441,7 +441,7 @@ class Image(IdlStruct, typename='sensor_msgs/Image'):
     """
     Header timestamp should be acquisition time of image
     Header frame_id should be optical frame of camera
-    origin of frame should be optical center of cameara
+    origin of frame should be optical center of camera
     +x should point to the right in the image
     +y should point down in the image
     +z should point into to plane of the image

--- a/edgefirst_msgs/msg/RadarCube.msg
+++ b/edgefirst_msgs/msg/RadarCube.msg
@@ -3,9 +3,9 @@
 
 # Radar Cube Message Interface - edgefirst/msg/RadarCube
 #
-# The RadarCube interface carries various radar cube reprensentations of the
+# The RadarCube interface carries various radar cube representations of the
 # Radar FFT before generally being processed by CFAR into a point cloud.  The
-# cube coud be R, RD, RAD, RA, and so on where R=Range, D=Dopper, and A=Azimuth.
+# cube could be R, RD, RAD, RA, and so on where R=Range, D=Doppler, and A=Azimuth.
 
 # Dimensional labels are used to describe the radar cube layout.  Not all cubes
 # include every label.  Undefined is used for dimensions not covered by this list.


### PR DESCRIPTION
Running `mkdocs build -s` in the user manual results in the following warnings:

```
WARNING -  mkdocs_spellcheck: (symspellpy) perception/api/edgefirst_msgs.md: Misspelled 'coud', did you mean 'could', 'cold', 'cord', 'cloud', 'cod', 'loud', 'coup', 'coed', 'crud', 'cud', 'oud'?
WARNING -  mkdocs_spellcheck: (codespell) perception/api/edgefirst_msgs.md: Misspelled 'coud', did you mean 'could'? WARNING -  mkdocs_spellcheck: (symspellpy) perception/api/edgefirst_msgs.md: Misspelled 'dopper', did you mean 'copper', 'hopper', 'doppler', 'topper', 'popper', 'dropper', 'dipper', 'dapper', 'bopper', 'lopper', 'mopper', 'doper'?
WARNING -  mkdocs_spellcheck: (symspellpy) perception/api/edgefirst_msgs.md: Misspelled 'reprensentations', did you mean 'representations'? 
WARNING -  mkdocs_spellcheck: (codespell) perception/api/edgefirst_msgs.md: Misspelled 'reprensentations', did you mean 'representations'? 
WARNING -  mkdocs_spellcheck: (symspellpy) perception/api/sensor_msgs.md: Misspelled 'cameara', did you mean 'camera'? 
WARNING -  mkdocs_spellcheck: (symspellpy) perception/api/sensor_msgs.md: Misspelled 'sufficent', did you mean 'sufficient'? 
WARNING -  mkdocs_spellcheck: (codespell) perception/api/sensor_msgs.md: Misspelled 'sufficent', did you mean 'sufficient'?
```