### PR TITLE
Restore Box alias for edgefirst_msgs.DetectBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`edgefirst_msgs.Box` backwards-compatibility alias.** The Python class
+  exposed as `Box` in the pure-Python module (<= 3.1.0) was renamed `DetectBox`
+  in 3.2.0 (when the package became a pyo3 binding) to avoid shadowing Rust's
+  `std::boxed::Box`. The rename was not flagged as a migration item, which broke
+  code and `mkdocstrings`-generated documentation referencing
+  `edgefirst.schemas.edgefirst_msgs.Box`. `Box` is now restored as an alias of
+  `DetectBox` (same class object), so both names resolve. New code should prefer
+  `DetectBox`.
+
 ## [3.4.0] - 2026-04-30
 
 ### Added

--- a/crates/python/python/edgefirst/schemas/edgefirst_msgs.pyi
+++ b/crates/python/python/edgefirst/schemas/edgefirst_msgs.pyi
@@ -13,6 +13,7 @@ from .std_msgs import Header
 from .geometry_msgs import Vector3
 
 __all__ = [
+    "Box",
     "CameraFrame",
     "CameraPlane",
     "Date",
@@ -338,6 +339,12 @@ class DetectBox:
     def track_lifetime(self) -> int: ...
     @property
     def track_created(self) -> Time: ...
+
+
+# Backwards-compatibility alias for the pre-3.2.0 name. `Box` was renamed
+# `DetectBox` when the module became a pyo3 binding (avoids shadowing Rust's
+# `std::boxed::Box`); the old name remains a resolvable alias of the same class.
+Box = DetectBox
 
 
 class Detect:

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -6787,6 +6787,13 @@ fn schemas(m: &Bound<'_, PyModule>) -> PyResult<()> {
     edgef.add_class::<PyVibration>()?;
     edgef.add_class::<PyModelInfo>()?;
     edgef.add_class::<PyDetectBox>()?;
+    // Backwards-compatibility alias: the message was exposed as `Box` in the
+    // pure-Python module (<= 3.1.0). When the package became a pyo3 binding in
+    // 3.2.0 the type was renamed `DetectBox` to avoid shadowing the Rust
+    // prelude's `std::boxed::Box`. Keep `Box` resolvable so pre-3.2.0 code and
+    // documentation that reference `edgefirst.schemas.edgefirst_msgs.Box`
+    // continue to work; both names point at the same class object.
+    edgef.add("Box", py.get_type::<PyDetectBox>())?;
     edgef.add_class::<PyDetect>()?;
     edgef.add_class::<PyCameraPlane>()?;
     edgef.add_class::<PyCameraFrame>()?;


### PR DESCRIPTION
## Summary

Restores `edgefirst.schemas.edgefirst_msgs.Box` as a backwards-compatibility alias of `DetectBox`.

`Box` was the Python class name in the pure-Python module (≤ 3.1.0). When the package became a pyo3 binding in **3.2.0**, the type was renamed `DetectBox` to avoid shadowing Rust's prelude `std::boxed::Box`. The rename was reasonable on the Rust side, but it was propagated to the Python-visible name (set explicitly via `#[pyclass(name = "DetectBox")]`) without being flagged as a migration item — even though Python has no `Box` conflict and pyo3 lets the Python name be chosen independently of the Rust struct.

That silently broke any consumer (and `mkdocstrings`-generated docs) referencing `edgefirst.schemas.edgefirst_msgs.Box`.

### Reported by

`matt-auzone` on the documentation repo:
> In edgefirst-schemas 3.4.0 there is no longer `edgefirst.schemas.edgefirst_msgs.Box`, it now seems to be `edgefirst.schemas.edgefirst_msgs.DetectBox`.
>
> ```
> ERROR   -  mkdocstrings: edgefirst.schemas.edgefirst_msgs.Box could not be found
> ```

(See EdgeFirstAI/documentation#117 review.)

## Changes

- **`crates/python/src/lib.rs`** — register `Box` in the `edgefirst_msgs` submodule as an alias of the same class object: `edgef.add("Box", py.get_type::<PyDetectBox>())?;`
- **`crates/python/python/edgefirst/schemas/edgefirst_msgs.pyi`** — add `Box = DetectBox` and list `"Box"` in `__all__` so static type-checkers see the alias too.
- **`CHANGELOG.md`** — document the alias under `[Unreleased]`.

The wire format and the ROS interface name (`edgefirst_msgs/Box`) were never changed; this only restores the Python identifier. New code should prefer `DetectBox`.

## Verification

- `cargo check` / `cargo fmt --check` — clean
- `maturin develop` + runtime check: `Box is DetectBox` → `True`; `Box(...)` constructs correctly
- `pytest tests/python/test_edgefirst_msgs.py` — 40 passed

## Notes

- No JIRA key (per maintainer direction for this change); branch uses the `feature/<description>` form.
- This is a backwards-compatible (MINOR) addition; version bump left to the release flow.
- Follow-up: the documentation repo can keep its existing `::: ...Box` reference (it will resolve once a release with this alias is published), but should ideally migrate to `DetectBox`.
